### PR TITLE
speedup isless productsector

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10' # replace with LTS once it is released
-          # - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'lts' # current lts release
+          - '1' # latest stable release
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorKitSectors"
 uuid = "13a9c161-d5da-41f0-bcbd-e1a08ae0647f"
 authors = ["Lukas Devos", "Jutho Haegeman"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -31,7 +31,7 @@ end
 end
 
 @inline localoffset(d, I::Tuple{Int}, sz::Tuple{Int}) = 0
-@inline function localoffset(d, I::NTuple{N,Int}, sz::Tuple{N,Int}) where {N}
+@inline function localoffset(d, I::NTuple{N,Int}, sz::NTuple{N,Int}) where {N}
     offset = 0
     for i in 1:(I[1] - 1)
         offset += num_manhattan_points(d - i + 1, Base.tail(sz))

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -31,7 +31,7 @@ end
 end
 
 @inline localoffset(d, I::Tuple{Int}, sz::Tuple{Int}) = 0
-@inline function localoffset(d, I, sz)
+@inline function localoffset(d, I::NTuple{N,Int}, sz::Tuple{N,Int}) where {N}
     offset = 0
     for i in 1:(I[1] - 1)
         offset += num_manhattan_points(d - i + 1, Base.tail(sz))
@@ -55,7 +55,7 @@ end
 
 # inverse mapping
 @inline invertlocaloffset(d, offset, sz::Tuple{Int}) = (d + 1,)
-@inline function invertlocaloffset(d, offset, sz)
+@inline function invertlocaloffset(d, offset, sz::Tuple{Int,Int,Vararg{Int}})
     i₁ = 1
     while i₁ < sz[1]
         jump = num_manhattan_points(d - i₁ + 1, Base.tail(sz))

--- a/src/irreps.jl
+++ b/src/irreps.jl
@@ -135,7 +135,7 @@ Base.conj(c::U1Irrep) = U1Irrep(-c.charge)
 ⊗(c1::U1Irrep, c2::U1Irrep) = (U1Irrep(c1.charge + c2.charge),)
 
 Base.IteratorSize(::Type{SectorValues{U1Irrep}}) = IsInfinite()
-function Base.iterate(::SectorValues{U1Irrep}, i=0)
+function Base.iterate(::SectorValues{U1Irrep}, i::Int=0)
     return i <= 0 ? (U1Irrep(half(i)), (-i + 1)) : (U1Irrep(half(i)), -i)
 end
 function Base.getindex(::SectorValues{U1Irrep}, i::Int)
@@ -188,7 +188,7 @@ Base.conj(s::SU2Irrep) = s
 ⊗(s1::SU2Irrep, s2::SU2Irrep) = SectorSet{SU2Irrep}(abs(s1.j - s2.j):(s1.j + s2.j))
 
 Base.IteratorSize(::Type{SectorValues{SU2Irrep}}) = IsInfinite()
-Base.iterate(::SectorValues{SU2Irrep}, i=0) = (SU2Irrep(half(i)), i + 1)
+Base.iterate(::SectorValues{SU2Irrep}, i::Int=0) = (SU2Irrep(half(i)), i + 1)
 function Base.getindex(::SectorValues{SU2Irrep}, i::Int)
     return 1 <= i ? SU2Irrep(half(i - 1)) : throw(BoundsError(values(SU2Irrep), i))
 end
@@ -269,7 +269,7 @@ Base.getindex(::IrrepTable, ::Type{CU₁}) = CU1Irrep
 Base.convert(::Type{CU1Irrep}, (j, s)::Tuple{Real,Integer}) = CU1Irrep(j, s)
 
 Base.IteratorSize(::Type{SectorValues{CU1Irrep}}) = IsInfinite()
-function Base.iterate(::SectorValues{CU1Irrep}, state=(0, 0))
+function Base.iterate(::SectorValues{CU1Irrep}, state::Tuple{Int,Int}=(0, 0))
     j, s = state
     if iszero(j) && s == 0
         return CU1Irrep(j, s), (j, 1)

--- a/src/product.jl
+++ b/src/product.jl
@@ -169,9 +169,13 @@ Base.hash(p::ProductSector, h::UInt) = hash(p.sectors, h)
 function Base.isless(p1::ProductSector{T}, p2::ProductSector{T}) where {T<:SectorTuple}
     I1 = findindex.(values.(_sectors(T)), p1.sectors)
     I2 = findindex.(values.(_sectors(T)), p2.sectors)
-    d1 = reverse(cumsum(I1 .- 1))
-    d2 = reverse(cumsum(I2 .- 1))
-    return isless(d1, d2)
+    d1 = cumsum(I1 .- 1)
+    d2 = cumsum(I2 .- 1)
+    n = length(d1)
+    n == 0 && return false
+    d1[n] < d2[n] && return true
+    d1[n] > d2[n] && return false
+    return isless(Base.front(d1), Base.front(d2))
 end
 
 # Default construction from tensor product of sectors

--- a/src/product.jl
+++ b/src/product.jl
@@ -166,8 +166,12 @@ dim(p::ProductSector) = *(dim.(p.sectors)...)
 
 Base.isequal(p1::ProductSector, p2::ProductSector) = isequal(p1.sectors, p2.sectors)
 Base.hash(p::ProductSector, h::UInt) = hash(p.sectors, h)
-function Base.isless(p1::P, p2::P) where {P<:ProductSector}
-    return isless(findindex(values(P), p1), findindex(values(P), p2))
+function Base.isless(p1::ProductSector{T}, p2::ProductSector{T}) where {T<:SectorTuple}
+    I1 = findindex.(values.(_sectors(T)), p1.sectors)
+    I2 = findindex.(values.(_sectors(T)), p2.sectors)
+    d1 = reverse(cumsum(I1 .- 1))
+    d2 = reverse(cumsum(I2 .- 1))
+    return isless(d1, d2)
 end
 
 # Default construction from tensor product of sectors

--- a/src/product.jl
+++ b/src/product.jl
@@ -169,13 +169,11 @@ Base.hash(p::ProductSector, h::UInt) = hash(p.sectors, h)
 function Base.isless(p1::ProductSector{T}, p2::ProductSector{T}) where {T<:SectorTuple}
     I1 = findindex.(values.(_sectors(T)), p1.sectors)
     I2 = findindex.(values.(_sectors(T)), p2.sectors)
-    d1 = cumsum(I1 .- 1)
-    d2 = cumsum(I2 .- 1)
-    n = length(d1)
-    n == 0 && return false
-    d1[n] < d2[n] && return true
-    d1[n] > d2[n] && return false
-    return isless(Base.front(d1), Base.front(d2))
+    d1 = sum(I1) - length(I1)
+    d2 = sum(I2) - length(I2)
+    d1 < d2 && return true
+    d1 > d2 && return false
+    return isless(I1, I2)
 end
 
 # Default construction from tensor product of sectors


### PR DESCRIPTION
Rather than computing the Manhattan index for defining `isless`, use that the Manhattan index is increasing in such a way that multidimensional indices are sorted first according to total manhattan distance to the origin, then among those with fixed total manhattan distance, sorted according to manhattan distance of the first N-1 indices, and so forth. 