### PR TITLE
minor typos

### DIFF
--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -39,10 +39,10 @@ abstract type Sector end
 Singleton type to represent an iterator over the possible values of type `I`, whose
 instance is obtained as `values(I)`. For a new `I::Sector`, the following should be defined
 *   `Base.iterate(::SectorValues{I}[, state])`: iterate over the values
-*   `Base.IteratorSize(::Type{SectorValues{I}})`: `HasLenght()`, `SizeUnkown()`
+*   `Base.IteratorSize(::Type{SectorValues{I}})`: `HasLength()`, `SizeUnknown()`
     or `IsInfinite()` depending on whether the number of values of type `I` is finite
     (and sufficiently small) or infinite; for a large number of values, `SizeUnknown()` is
-    recommend because this will trigger the use of `GenericGradedSpace`.
+    recommended because this will trigger the use of `GenericGradedSpace`.
 If `IteratorSize(I) == HasLength()`, also the following must be implemented:
 *   `Base.length(::SectorValues{I})`: the number of different values
 *   `Base.getindex(::SectorValues{I}, i::Int)`: a mapping between an index `i` and an
@@ -413,7 +413,7 @@ end
 
 # SectorSet:
 #-------------------------------------------------------------------------------
-# Custum generator to represent sets of sectors with type inference
+# Custom generator to represent sets of sectors with type inference
 struct SectorSet{I<:Sector,F,S}
     f::F
     set::S


### PR DESCRIPTION
Found some minor typos in the docstring of `Sector`. I won't promise this time that I found them all ;)