### PR TITLE
Compatibility with MultiTensorKit

### DIFF
--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -17,6 +17,7 @@ export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion,
        MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic
 export SectorSet, SectorValues, findindex
+export rightone, leftone
 
 export pentagon_equation, hexagon_equation
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -279,7 +279,8 @@ number. Otherwise it is a square matrix with row and column size
 """
 function Bsymbol(a::I, b::I, c::I) where {I<:Sector}
     if FusionStyle(I) isa UniqueFusion || FusionStyle(I) isa SimpleFusion
-        (sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) * Fsymbol(a, b, dual(b), a, c, rightone(a))
+        (sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) *
+        Fsymbol(a, b, dual(b), a, c, rightone(a))
     else
         reshape((sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) *
                 Fsymbol(a, b, dual(b), a, c, rightone(a)),

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -255,10 +255,10 @@ end
 function Asymbol(a::I, b::I, c::I) where {I<:Sector}
     if FusionStyle(I) isa UniqueFusion || FusionStyle(I) isa SimpleFusion
         (sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) *
-        conj(frobeniusschur(a) * Fsymbol(dual(a), a, b, b, one(a), c))
+        conj(frobeniusschur(a) * Fsymbol(dual(a), a, b, b, leftone(a), c))
     else
         reshape((sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) *
-                conj(frobeniusschur(a) * Fsymbol(dual(a), a, b, b, one(a), c)),
+                conj(frobeniusschur(a) * Fsymbol(dual(a), a, b, b, leftone(a), c)),
                 (Nsymbol(a, b, c), Nsymbol(dual(a), c, b)))
     end
 end

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -245,9 +245,9 @@ Return the Frobenius-Schur indicator of a sector `a`.
 """
 function frobeniusschur(a::Sector)
     if FusionStyle(a) isa UniqueFusion || FusionStyle(a) isa SimpleFusion
-        sign(Fsymbol(a, conj(a), a, a, one(a), one(a)))
+        sign(Fsymbol(a, conj(a), a, a, leftone(a), rightone(a)))
     else
-        sign(Fsymbol(a, conj(a), a, a, one(a), one(a))[1])
+        sign(Fsymbol(a, conj(a), a, a, leftone(a), rightone(a))[1])
     end
 end
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -279,10 +279,10 @@ number. Otherwise it is a square matrix with row and column size
 """
 function Bsymbol(a::I, b::I, c::I) where {I<:Sector}
     if FusionStyle(I) isa UniqueFusion || FusionStyle(I) isa SimpleFusion
-        (sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) * Fsymbol(a, b, dual(b), a, c, one(a))
+        (sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) * Fsymbol(a, b, dual(b), a, c, rightone(a))
     else
         reshape((sqrtdim(a) * sqrtdim(b) * invsqrtdim(c)) *
-                Fsymbol(a, b, dual(b), a, c, one(a)),
+                Fsymbol(a, b, dual(b), a, c, rightone(a)),
                 (Nsymbol(a, b, c), Nsymbol(c, dual(b), a)))
     end
 end

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -90,9 +90,16 @@ end
 
 Return the unit element within this type of sector.
 """
-rightone(a::Sector) = one(a)
-leftone(a::Sector) = one(a)
 Base.one(a::Sector) = one(typeof(a))
+
+"""
+    leftone(a::Sector) -> Sector
+    rightone(a::Sector) -> Sector
+
+Return the left or right unit element within this type of sector. 
+"""
+leftone(a::Sector) = one(a)
+rightone(a::Sector) = one(a)
 
 """
     dual(a::Sector) -> Sector

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -90,6 +90,8 @@ end
 
 Return the unit element within this type of sector.
 """
+rightone(a::Sector) = one(a)
+leftone(a::Sector) = one(a)
 Base.one(a::Sector) = one(typeof(a))
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -94,11 +94,18 @@ Base.one(a::Sector) = one(typeof(a))
 
 """
     leftone(a::Sector) -> Sector
-    rightone(a::Sector) -> Sector
 
-Return the left or right unit element within this type of sector. 
+Return the left unit element within this type of sector.
+See also [`rightone`](@ref) and [`Base.one`](@ref).
 """
 leftone(a::Sector) = one(a)
+
+"""
+    rightone(a::Sector) -> Sector
+
+Return the right unit element within this type of sector.
+See also [`leftone`](@ref) and [`Base.one`](@ref).
+"""
 rightone(a::Sector) = one(a)
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -230,9 +230,9 @@ function dim(a::Sector)
     if FusionStyle(a) isa UniqueFusion
         1
     elseif FusionStyle(a) isa SimpleFusion
-        abs(1 / Fsymbol(a, conj(a), a, a, one(a), one(a)))
+        abs(1 / Fsymbol(a, conj(a), a, a, leftone(a), rightone(a)))
     else
-        abs(1 / Fsymbol(a, conj(a), a, a, one(a), one(a))[1])
+        abs(1 / Fsymbol(a, conj(a), a, a, leftone(a), rightone(a))[1])
     end
 end
 sqrtdim(a::Sector) = (FusionStyle(a) isa UniqueFusion) ? 1 : sqrt(dim(a))


### PR DESCRIPTION
This PR contains the necessary changes within TensorKitSectors to be compatible with MultiTensorKit. It comes down to evaluating left and right units within F-symbols.