### PR TITLE
[Feature] `Tuple(::ProductSector)`

### DIFF
--- a/src/product.jl
+++ b/src/product.jl
@@ -13,6 +13,8 @@ struct ProductSector{T <: SectorTuple} <: Sector
     sectors::T
 end
 
+Base.Tuple(a::ProductSector) = a.sectors
+
 Base.getindex(s::ProductSector, i::Int) = getindex(s.sectors, i)
 Base.iterate(s::ProductSector, args...) = iterate(s.sectors, args...)
 Base.indexed_iterate(s::ProductSector, args...) = Base.indexed_iterate(s.sectors, args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,7 @@ end
         @constinferred I1 ⊠ I2
         @test typeof(a ⊠ b) == I1 ⊠ I2
     end
+    @test @constinferred(Tuple(SU2Irrep(1) ⊠ U1Irrep(0))) == (SU2Irrep(1), U1Irrep(0))
 end
 
 @testset "Issue that came up in #11" begin


### PR DESCRIPTION
This PR adds a small utility function for unpacking a product sector, similar to how `Tuple(CartesianIndex(1, 1))` is the recommended way of unpacking for Base objects.