### PR TITLE
[Feature] `length(::ProductSector)`

### DIFF
--- a/src/product.jl
+++ b/src/product.jl
@@ -16,6 +16,7 @@ end
 Base.Tuple(a::ProductSector) = a.sectors
 
 Base.getindex(s::ProductSector, i::Int) = getindex(s.sectors, i)
+Base.length(s::ProductSector) = length(s.sectors)
 Base.iterate(s::ProductSector, args...) = iterate(s.sectors, args...)
 Base.indexed_iterate(s::ProductSector, args...) = Base.indexed_iterate(s.sectors, args...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ end
         @test typeof(a ⊠ b) == I1 ⊠ I2
     end
     @test @constinferred(Tuple(SU2Irrep(1) ⊠ U1Irrep(0))) == (SU2Irrep(1), U1Irrep(0))
+    @test @constinferred(length(FermionParity(1) ⊠ SU2Irrep(1 // 2) ⊠ U1Irrep(1))) == 3
 end
 
 @testset "Issue that came up in #11" begin


### PR DESCRIPTION
This PR adds a small utility function for getting the number of factors in a `ProductSector`. This seemed appropriate since indexing and iteration are both supported, and avoids having to unpack anything.