### PR TITLE
Add type representation for U₁ and CU₁

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -23,6 +23,8 @@ type_repr(::Type{ℤ₄}) = "ℤ₄"
 type_repr(::Type{D₃}) = "D₃"
 type_repr(::Type{D₄}) = "D₄"
 type_repr(::Type{SU₂}) = "SU₂"
+type_repr(::Type{U₁}) = "U₁"
+type_repr(::Type{CU₁}) = "CU₁"
 type_repr(T::Type) = repr(T)
 
 const GroupTuple = Tuple{Vararg{Group}}


### PR DESCRIPTION
These seem to have been missing for some reason.