### PR TITLE
`FusionDataStyle` type

### DIFF
--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -12,6 +12,7 @@ export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion,
     MultiplicityFreeFusion
 export UnitStyle, SimpleUnit, GenericUnit
+export FusionDataStyle, TrivialFusionData, NonTrivialFusionData
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic
 export SectorSet, SectorValues, findindex
 export unit, rightunit, leftunit, allunits, isunit

--- a/src/anyons.jl
+++ b/src/anyons.jl
@@ -198,6 +198,7 @@ dual(s::IsingAnyon) = s
 dim(a::IsingAnyon) = a.s == :σ ? sqrt(2) : 1.0
 
 FusionStyle(::Type{IsingAnyon}) = SimpleFusion()
+FusionDataStyle(::Type{IsingAnyon}) = NonTrivialFusionData()
 BraidingStyle(::Type{IsingAnyon}) = Anyonic()
 Base.isreal(::Type{IsingAnyon}) = false
 

--- a/src/anyons.jl
+++ b/src/anyons.jl
@@ -27,6 +27,7 @@ unit(::Type{PlanarTrivial}) = PlanarTrivial()
 dual(::PlanarTrivial) = PlanarTrivial()
 
 FusionStyle(::Type{PlanarTrivial}) = UniqueFusion()
+FusionDataStyle(::Type{PlanarTrivial}) = TrivialFusionData()
 BraidingStyle(::Type{PlanarTrivial}) = NoBraiding()
 Base.isreal(::Type{PlanarTrivial}) = true
 
@@ -82,6 +83,7 @@ const _goldenratio = Float64(MathConstants.golden)
 dim(a::FibonacciAnyon) = isunit(a) ? one(_goldenratio) : _goldenratio
 
 FusionStyle(::Type{FibonacciAnyon}) = SimpleFusion()
+FusionDataStyle(::Type{FibonacciAnyon}) = NonTrivialFusionData()
 BraidingStyle(::Type{FibonacciAnyon}) = Anyonic()
 Base.isreal(::Type{FibonacciAnyon}) = false
 

--- a/src/fermions.jl
+++ b/src/fermions.jl
@@ -35,6 +35,7 @@ dual(f::FermionParity) = f
 dim(f::FermionParity) = 1
 
 FusionStyle(::Type{FermionParity}) = UniqueFusion()
+FusionDataStyle(::Type{FermionParity}) = TrivialFusionData()
 BraidingStyle(::Type{FermionParity}) = Fermionic()
 Base.isreal(::Type{FermionParity}) = true
 

--- a/src/groupelements.jl
+++ b/src/groupelements.jl
@@ -30,6 +30,7 @@ the cocycle will be assumed to be trivial, i.e. equal to `1`.
 """
 abstract type AbstractGroupElement{G <: Group} <: Sector end
 FusionStyle(::Type{<:AbstractGroupElement}) = UniqueFusion()
+FusionDataStyle(::Type{<:AbstractGroupElement}) = NonTrivialFusionData()
 BraidingStyle(::Type{<:AbstractGroupElement}) = NoBraiding()
 
 cocycle(a::I, b::I, c::I) where {I <: AbstractGroupElement} = 1
@@ -149,6 +150,7 @@ Base.hash(c::ZNElement, h::UInt) = hash(c.n, h)
 Base.isless(c1::ZNElement{N, p}, c2::ZNElement{N, p}) where {N, p} = isless(c1.n, c2.n)
 
 # Experimental
+FusionDataStyle(::Type{ZNElement{N, p}}) where {N, p} = p == 0 ? TrivialFusionData() : NonTrivialFusionData()
 BraidingStyle(::Type{ZNElement{N, 0}}) where {N} = Bosonic()
 Rsymbol(a::ZNElement{N, 0}, b::ZNElement{N, 0}, c::ZNElement{N, 0}) where {N} = ifelse(a * b == c, 1, zero(1))
 

--- a/src/irreps/a4irrep.jl
+++ b/src/irreps/a4irrep.jl
@@ -18,6 +18,7 @@ struct A4Irrep <: AbstractIrrep{A₄}
 end
 
 FusionStyle(::Type{A4Irrep}) = GenericFusion()
+FusionDataStyle(::Type{A4Irrep}) = NonTrivialFusionData()
 sectorscalartype(::Type{A4Irrep}) = Float64
 
 unit(::Type{A4Irrep}) = A4Irrep(0)

--- a/src/irreps/cu1irrep.jl
+++ b/src/irreps/cu1irrep.jl
@@ -107,6 +107,7 @@ end
 dim(c::CU1Irrep) = ifelse(c.j == zero(HalfInt), 1, 2)
 
 FusionStyle(::Type{CU1Irrep}) = SimpleFusion()
+FusionDataStyle(::Type{CU1Irrep}) = NonTrivialFusionData()
 sectorscalartype(::Type{CU1Irrep}) = Float64
 Base.isreal(::Type{CU1Irrep}) = true
 

--- a/src/irreps/dnirrep.jl
+++ b/src/irreps/dnirrep.jl
@@ -44,6 +44,7 @@ function Base.getproperty(a::DNIrrep{N}, sym::Symbol) where {N}
 end
 
 FusionStyle(::Type{DNIrrep{N}}) where {N} = N < 3 ? UniqueFusion() : SimpleFusion()
+FusionDataStyle(::Type{DNIrrep{N}}) where {N} = N < 3 ? TrivialFusionData() : NonTrivialFusionData()
 sectorscalartype(::Type{DNIrrep{N}}) where {N} = Float64
 Base.isreal(::Type{DNIrrep{N}}) where {N} = true
 

--- a/src/irreps/irreps.jl
+++ b/src/irreps/irreps.jl
@@ -48,6 +48,7 @@ end
 
 const AbelianIrrep{G} = AbstractIrrep{G} where {G <: AbelianGroup}
 FusionStyle(::Type{<:AbelianIrrep}) = UniqueFusion()
+FusionDataStyle(::Type{<:AbelianIrrep}) = TrivialFusionData()
 Base.isreal(::Type{<:AbelianIrrep}) = true
 
 Nsymbol(a::I, b::I, c::I) where {I <: AbelianIrrep} = c == first(a ⊗ b)

--- a/src/irreps/su2irrep.jl
+++ b/src/irreps/su2irrep.jl
@@ -43,6 +43,7 @@ findindex(::SectorValues{SU2Irrep}, s::SU2Irrep) = twice(s.j) + 1
 dim(s::SU2Irrep) = twice(s.j) + 1
 
 FusionStyle(::Type{SU2Irrep}) = SimpleFusion()
+FusionDataStyle(::Type{SU2Irrep}) = NonTrivialFusionData()
 sectorscalartype(::Type{SU2Irrep}) = Float64
 Base.isreal(::Type{SU2Irrep}) = true
 

--- a/src/multifusion.jl
+++ b/src/multifusion.jl
@@ -56,6 +56,7 @@ function Base.convert(::Type{IsingAnyon}, a::IsingBimodule) # identify RepZ2 ⊕
 end
 
 FusionStyle(::Type{IsingBimodule}) = SimpleFusion() # no multiplicities
+FusionDataStyle(::Type{IsingBimodule}) = NonTrivialFusionData()
 BraidingStyle(::Type{IsingBimodule}) = NoBraiding() # because of module categories
 
 function Nsymbol(a::IsingBimodule, b::IsingBimodule, c::IsingBimodule)

--- a/src/product.jl
+++ b/src/product.jl
@@ -215,6 +215,9 @@ end
 function FusionStyle(::Type{<:ProductSector{T}}) where {T <: SectorTuple}
     return mapreduce(FusionStyle, &, _sectors(T))
 end
+function FusionDataStyle(::Type{<:ProductSector{T}}) where {T <: SectorTuple}
+    return mapreduce(FusionDataStyle, &, _sectors(T))
+end
 function UnitStyle(::Type{<:ProductSector{T}}) where {T <: SectorTuple}
     return mapreduce(UnitStyle, &, _sectors(T))
 end

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -317,6 +317,35 @@ Base.:&(::SimpleFusion, ::UniqueFusion) = SimpleFusion()
 Base.:&(::GenericFusion, ::UniqueFusion) = GenericFusion()
 Base.:&(::GenericFusion, ::SimpleFusion) = GenericFusion()
 
+# trait to differentiate between trivial and non-trivial F-symbols
+"""
+    abstract type FusionDataStyle
+    FusionDataStyle(::Sector)
+    FusionDataStyle(I::Type{<:Sector})
+
+Trait to describe the fusion behavior of sectors of type `I`, which can be either
+*   `TrivialFusionData()`: All F-symbols are trivial (equal to `0` or `1`);
+*   `NonTrivialFusionData()`: Some F-symbols are non-trivial;
+
+
+This is most important for sectors with `FusionStyle(I) == UniqueFusion()`, where
+`NonTrivialFusionData()` requires a proper evaluation of the F-symbols when manipulating
+fusion trees, while `TrivialFusionData()` allows to skip all F-symbol evaluations.
+"""
+abstract type FusionDataStyle end
+FusionDataStyle(a::Sector) = FusionDataStyle(typeof(a))
+
+struct TrivialFusionData <: FusionDataStyle end
+struct NonTrivialFusionData <: FusionDataStyle end
+
+# combine fusion data properties of tensor products of sectors
+Base.:&(f::F, ::F) where {F <: FusionDataStyle} = f
+Base.:&(f₁::FusionDataStyle, f₂::FusionDataStyle) = f₂ & f₁
+
+Base.:&(::TrivialFusionData, ::TrivialFusionData) = TrivialFusionData()
+Base.:&(::TrivialFusionData, ::NonTrivialFusionData) = NonTrivialFusionData()
+Base.:&(::NonTrivialFusionData, ::NonTrivialFusionData) = NonTrivialFusionData()
+
 # similar, but for multifusion categories
 """
     abstract type UnitStyle

--- a/src/timereversed.jl
+++ b/src/timereversed.jl
@@ -18,6 +18,7 @@ struct TimeReversed{I <: Sector} <: Sector
     end
 end
 FusionStyle(::Type{TimeReversed{I}}) where {I <: Sector} = FusionStyle(I)
+FusionDataStyle(::Type{TimeReversed{I}}) where {I <: Sector} = FusionDataStyle(I)
 BraidingStyle(::Type{TimeReversed{I}}) where {I <: Sector} = BraidingStyle(I)
 function Nsymbol(
         a::TimeReversed{I}, b::TimeReversed{I}, c::TimeReversed{I}

--- a/src/trivial.jl
+++ b/src/trivial.jl
@@ -30,6 +30,7 @@ Base.isless(::Trivial, ::Trivial) = false
 ⊗(::Trivial, ::Trivial) = (Trivial(),)
 Nsymbol(::Trivial, ::Trivial, ::Trivial) = true
 FusionStyle(::Type{Trivial}) = UniqueFusion()
+FusionDataStyle(::Type{Trivial}) = TrivialFusionData()
 Fsymbol(::Trivial, ::Trivial, ::Trivial, ::Trivial, ::Trivial, ::Trivial) = 1
 fusiontensor(::Trivial, ::Trivial, ::Trivial) = fill(1, (1, 1, 1, 1))
 

--- a/test/multifusion.jl
+++ b/test/multifusion.jl
@@ -8,6 +8,7 @@ Istr = TensorKitSectors.type_repr(I)
         prodsec = I ⊠ Z2Irrep
         @test UnitStyle(prodsec) isa GenericUnit
         @test FusionStyle(prodsec) isa SimpleFusion
+        @test FusionDataStyle(prodsec) isa NonTrivialFusionData
         @test_throws DomainError unit(prodsec)
         @test length(allunits(prodsec)) == 2
     end

--- a/test/newsectors.jl
+++ b/test/newsectors.jl
@@ -12,7 +12,7 @@ using HalfIntegers
 using WignerSymbols
 using TensorKitSectors
 
-import TensorKitSectors: FusionStyle, BraidingStyle, Nsymbol, Fsymbol, Rsymbol, dim,
+import TensorKitSectors: FusionStyle, BraidingStyle, FusionDataStyle, Nsymbol, Fsymbol, Rsymbol, dim,
     fusiontensor, ⊗, unit, dual
 
 struct NewSU2Irrep <: Sector

--- a/test/newsectors.jl
+++ b/test/newsectors.jl
@@ -35,6 +35,7 @@ Base.IteratorSize(::Type{SectorValues{NewSU2Irrep}}) = Base.IsInfinite()
 Base.iterate(::SectorValues{NewSU2Irrep}, i = 0) = (NewSU2Irrep(half(i)), i + 1)
 
 FusionStyle(::Type{NewSU2Irrep}) = GenericFusion()
+FusionDataStyle(::Type{NewSU2Irrep}) = NonTrivialFusionData()
 BraidingStyle(::Type{NewSU2Irrep}) = Bosonic()
 Base.isreal(::Type{NewSU2Irrep}) = true
 

--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -30,6 +30,9 @@ using LinearAlgebra
             @test eltype(F) <: @testinferred sectorscalartype(I)
         end
     end
+    if FusionStyle(I) != UniqueFusion()
+        @test FusionDataStyle(I) === NonTrivialFusionData()
+    end
     @testinferred(s[1] ⊗ s[2])
     @testinferred(⊗(s..., s...))
 end


### PR DESCRIPTION
This PR is a proposal to fix QuantumKitHub/TensorKit.jl#245. This allows us to keep `UniqueFusion` the way it is, and is an easier solution to rewriting `TensorKit.foldright` itself. Specifically, https://github.com/QuantumKitHub/TensorKit.jl/blob/155aa8997ef8eba1dfa53cd368097ae41aa2a10b/src/fusiontrees/manipulations.jl#L352 would then have an additional `&& FusionDataStyle(I) isa TrivialFusionData` check. Testing locally with `I = Z2Element{1}` and this passes the transpose tests.*

I didn't think too hard about the name. Other options I can think of are `AssociatorStyle` and `RecouplingStyle`. All these names have their merits and demerits. I also didn't think if this was the ideal approach, but I just wanted to get the ball rolling.

*Unrelated to this PR, but as of now  `Z2Element{1}` passes all TensorKit tests, and `Z3Element{1}` passes the transpose tests, but fail at braiding tests. Still looking into this, but it seems that the non-self-dual nature and non-trivial F-symbols are messing things up somewhere, even if I blindly add the `FusionDataStyle` check where `UniqueFusion` is checked. This is a WIP, just wanted to mention it here already.