### PR TITLE
change isreal to sectorscalartype

### DIFF
--- a/src/anyons.jl
+++ b/src/anyons.jl
@@ -28,7 +28,7 @@ dual(::PlanarTrivial) = PlanarTrivial()
 
 FusionStyle(::Type{PlanarTrivial}) = UniqueFusion()
 BraidingStyle(::Type{PlanarTrivial}) = NoBraiding()
-Base.isreal(::Type{PlanarTrivial}) = true
+sectorscalartype(::Type{PlanarTrivial}) = Int
 
 Nsymbol(::Vararg{PlanarTrivial, 3}) = 1
 Fsymbol(::Vararg{PlanarTrivial, 6}) = 1
@@ -83,7 +83,7 @@ dim(a::FibonacciAnyon) = isunit(a) ? one(_goldenratio) : _goldenratio
 
 FusionStyle(::Type{FibonacciAnyon}) = SimpleFusion()
 BraidingStyle(::Type{FibonacciAnyon}) = Anyonic()
-Base.isreal(::Type{FibonacciAnyon}) = false
+sectorscalartype(::Type{FibonacciAnyon}) = ComplexF64
 
 const FibonacciAnyonProdIterator = SectorProductIterator{FibonacciAnyon}
 
@@ -199,7 +199,7 @@ dim(a::IsingAnyon) = a.s == :σ ? sqrt(2) : 1.0
 
 FusionStyle(::Type{IsingAnyon}) = SimpleFusion()
 BraidingStyle(::Type{IsingAnyon}) = Anyonic()
-Base.isreal(::Type{IsingAnyon}) = false
+sectorscalartype(::Type{IsingAnyon}) = ComplexF64
 
 const IsingAnyonProdIterator = SectorProductIterator{IsingAnyon}
 

--- a/src/fermions.jl
+++ b/src/fermions.jl
@@ -36,7 +36,7 @@ dim(f::FermionParity) = 1
 
 FusionStyle(::Type{FermionParity}) = UniqueFusion()
 BraidingStyle(::Type{FermionParity}) = Fermionic()
-Base.isreal(::Type{FermionParity}) = true
+sectorscalartype(::Type{FermionParity}) = Int
 
 ⊗(a::FermionParity, b::FermionParity) = (FermionParity(a.isodd ⊻ b.isodd),)
 

--- a/src/irreps/dnirrep.jl
+++ b/src/irreps/dnirrep.jl
@@ -45,7 +45,6 @@ end
 
 FusionStyle(::Type{DNIrrep{N}}) where {N} = N < 3 ? UniqueFusion() : SimpleFusion()
 sectorscalartype(::Type{DNIrrep{N}}) where {N} = Float64
-Base.isreal(::Type{DNIrrep{N}}) where {N} = true
 
 unit(::Type{DNIrrep{N}}) where {N} = DNIrrep{N}(0, false)
 dual(a::DNIrrep) = a

--- a/src/irreps/irreps.jl
+++ b/src/irreps/irreps.jl
@@ -48,7 +48,7 @@ end
 
 const AbelianIrrep{G} = AbstractIrrep{G} where {G <: AbelianGroup}
 FusionStyle(::Type{<:AbelianIrrep}) = UniqueFusion()
-Base.isreal(::Type{<:AbelianIrrep}) = true
+sectorscalartype(::Type{<:AbelianIrrep}) = Int
 
 Nsymbol(a::I, b::I, c::I) where {I <: AbelianIrrep} = c == first(a ⊗ b)
 function Fsymbol(a::I, b::I, c::I, d::I, e::I, f::I) where {I <: AbelianIrrep}

--- a/src/irreps/su2irrep.jl
+++ b/src/irreps/su2irrep.jl
@@ -44,7 +44,6 @@ dim(s::SU2Irrep) = twice(s.j) + 1
 
 FusionStyle(::Type{SU2Irrep}) = SimpleFusion()
 sectorscalartype(::Type{SU2Irrep}) = Float64
-Base.isreal(::Type{SU2Irrep}) = true
 
 Nsymbol(sa::SU2Irrep, sb::SU2Irrep, sc::SU2Irrep) = WignerSymbols.δ(sa.j, sb.j, sc.j)
 

--- a/src/product.jl
+++ b/src/product.jl
@@ -221,8 +221,8 @@ end
 function BraidingStyle(::Type{<:ProductSector{T}}) where {T <: SectorTuple}
     return mapreduce(BraidingStyle, &, _sectors(T))
 end
-function Base.isreal(::Type{<:ProductSector{T}}) where {T <: SectorTuple}
-    return mapreduce(isreal, &, _sectors(T))
+function sectorscalartype(::Type{<:ProductSector{T}}) where {T <: SectorTuple}
+    return mapreduce(sectorscalartype, promote_type, _sectors(T))
 end
 
 fermionparity(P::ProductSector) = mapreduce(fermionparity, xor, P.sectors)

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -17,9 +17,11 @@ Every new `I <: Sector` should implement the following methods:
     `GenericFusion()`
 *   `BraidingStyle(::Type{I})`: `Bosonic()`, `Fermionic()`, `Anyonic()`, ...
 *   `Fsymbol(a::I, b::I, c::I, d::I, e::I, f::I)`: F-symbol: scalar (in case of
-    `UniqueFusion`/`SimpleFusion`) or matrix (in case of `GenericFusion`)
+    `UniqueFusion`/`SimpleFusion`) or rank-4 array (in case of `GenericFusion`)
 *   `Rsymbol(a::I, b::I, c::I)`: R-symbol: scalar (in case of
     `UniqueFusion`/`SimpleFusion`) or matrix (in case of `GenericFusion`)
+*   `isless(a::I, b::I)`: defines a canonical ordering of sectors
+*   `hash(a::I)`: hash function for sectors
 and optionally
 *   `dim(a::I)`: quantum dimension of sector `a`
 *   `frobenius_schur_indicator(a::I)`: Frobenius-Schur indicator of `a` (1, 0, -1)
@@ -162,7 +164,7 @@ Base.conj(a::Sector) = dual(a)
 """
     sectorscalartype(I::Type{<:Sector}) -> Type
 
-Return the scalar type of the topological data (Fsymbol, Rsymbol) of the sector `I`.
+Return the scalar type of the topological data ([`Fsymbol`](@ref) and [`Rsymbol`](@ref)) of the sector `I`.
 """
 function sectorscalartype(::Type{I}) where {I <: Sector}
     if BraidingStyle(I) === NoBraiding()

--- a/src/trivial.jl
+++ b/src/trivial.jl
@@ -22,9 +22,8 @@ findindex(::SectorValues{Trivial}, c::Trivial) = 1
 # basic properties
 unit(::Type{Trivial}) = Trivial()
 dual(::Trivial) = Trivial()
-
-Base.isreal(::Type{Trivial}) = true
 Base.isless(::Trivial, ::Trivial) = false
+sectorscalartype(::Type{Trivial}) = Int
 
 # fusion rules
 ⊗(::Trivial, ::Trivial) = (Trivial(),)


### PR DESCRIPTION
This changes some legacy `Base.isreal` definitions into proper `sectorscalartype` definitions. Once these are in place, and do no longer fall back to the inference-based default implementation, the default `Base.isreal` implementation should work fine.