### PR TITLE
Extract gauge invariant braided category data

### DIFF
--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, Smatrix, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, topological_spin, hopflink, Tvector, Smatrix, anyonbasis, anyonindex, topological_central_charge, sqDim, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, topological_spin, hopflink, Tmatrix, Smatrix, anyonbasis, anyonindex, topological_central_charge, sqdim, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic
@@ -60,7 +60,7 @@ using Base: HasEltype, EltypeUnknown
 using Base.Iterators: product, filter
 using Base: @assume_effects
 
-using LinearAlgebra: tr
+using LinearAlgebra: tr, Diagonal
 using TensorOperations
 using HalfIntegers
 using WignerSymbols

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, Smatrix, ξ, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, hopflink, Tvector, Smatrix, ξ, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, Smatrix, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, Smatrix, ξ, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, hopflink, Tvector, Smatrix, topological_central_charge, sqDim, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, hopflink, Tvector, Smatrix, c_top, sqDim, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,8 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, topological_spin, hopflink, Tmatrix, Smatrix, anyonbasis, anyonindex, topological_central_charge, sqdim, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, fusiontensor, dual
+export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, istransparent, mugercenter, anyonbasis, anyonindex, topological_central_charge, sqdim
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic
@@ -60,7 +61,7 @@ using Base: HasEltype, EltypeUnknown
 using Base.Iterators: product, filter
 using Base: @assume_effects
 
-using LinearAlgebra: tr, Diagonal
+using LinearAlgebra: tr, Diagonal, I
 using TensorOperations
 using HalfIntegers
 using WignerSymbols

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, spin_top, hopflink, Tvector, Smatrix, c_top, sqDim, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, topological_spin, hopflink, Tvector, Smatrix, topological_central_charge, sqDim, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, hopflink, Tvector, Smatrix, c_top, sqDim, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, spin_top, hopflink, Tvector, Smatrix, c_top, sqDim, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -8,7 +8,7 @@ export Irrep, GroupElement
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
 export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, fusiontensor, dual
-export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, istransparent, transparent_anyons, anyonbasis, topological_central_charge, sqdim
+export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, topological_central_charge
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, topological_spin, hopflink, Tvector, Smatrix, topological_central_charge, sqDim, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, topological_spin, hopflink, Tvector, Smatrix, anyonbasis, anyonindex, topological_central_charge, sqDim, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -7,7 +7,7 @@ export Irrep, GroupElement
 
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
-export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, hopflink, Tvector, Smatrix, ξ, fusiontensor, dual
+export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, hopflink, Tvector, Smatrix, topological_central_charge, sqDim, fusiontensor, dual
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -8,7 +8,7 @@ export Irrep, GroupElement
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
 export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, fusiontensor, dual
-export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, istransparent, transparent_anyons, anyonbasis, anyonindex, topological_central_charge, sqdim
+export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, istransparent, transparent_anyons, anyonbasis, topological_central_charge, sqdim
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -8,7 +8,7 @@ export Irrep, GroupElement
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
 export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, fusiontensor, dual
-export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, istransparent, mugercenter, anyonbasis, anyonindex, topological_central_charge, sqdim
+export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, istransparent, transparent_anyons, anyonbasis, anyonindex, topological_central_charge, sqdim
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/product.jl
+++ b/src/product.jl
@@ -260,7 +260,7 @@ fermionparity(p::ProductSector) = mapreduce(fermionparity, xor, p.sectors)
 
 dim(p::ProductSector) = *(dim.(p.sectors)...)
 twist(p::ProductSector) = *(twist.(p.sectors)...)
-hopflink(p::I, q::I) where {I <: ProductSector} = *(map(x -> hopflink(x...), zip(p.sectors, q.sectors))...)
+hopflink(p::I, q::I) where {I <: ProductSector} = *(hopflink.(p.sectors, q.sectors)...)
 
 Base.isequal(p1::ProductSector, p2::ProductSector) = isequal(p1.sectors, p2.sectors)
 Base.hash(p::ProductSector, h::UInt) = hash(p.sectors, h)

--- a/src/product.jl
+++ b/src/product.jl
@@ -25,6 +25,12 @@ Base.indexed_iterate(s::ProductSector, args...) = Base.indexed_iterate(s.sectors
 _sectors(::Type{ProductSector{T}}) where {T} = Base.fieldtypes(T)
 _sectors(::Type) = error("should never be reached") # keeps JET happy
 
+function _kron_iter(::Type{ProductSector{T}}) where {T} # Construct an iterator with the same order as the Kronecker product.
+    tuple_iterators = values.(Base.fieldtypes(T))
+    @assert !any(it -> Base.IteratorSize(it) isa Base.IsInfinite, tuple_iterators) "All sectors need to be finite"
+    return (ProductSector{T}(reverse(x)) for x in Iterators.product(reverse(tuple_iterators)...))
+end
+
 function Base.IteratorSize(::Type{SectorValues{I}}) where {I <: ProductSector}
     return Base.IteratorSize(Base.Iterators.product(map(values, _sectors(I))...))
 end
@@ -40,13 +46,11 @@ function _size(::SectorValues{I}) where {I <: ProductSector}
     return map(s -> _length(values(s)), _sectors(I))
 end
 function Base.getindex(P::SectorValues{I}, i::Int) where {I <: ProductSector}
-    inds = Base.IteratorSize(P) === Base.IsInfinite() ? manhattan_to_multidimensional_index(i, _size(P)) : reverse(Tuple(CartesianIndices(reverse(_size(P)))[i]))
+    inds = manhattan_to_multidimensional_index(i, _size(P))
     return I(getindex.(values.(_sectors(I)), inds))
 end
 function findindex(P::SectorValues{I}, c::I) where {I <: ProductSector}
-    index_tuple = findindex.(values.(_sectors(I)), Tuple(c))
-    ind = Base.IteratorSize(P) === Base.IsInfinite() ? to_manhattan_index(index_tuple, _size(P)) : LinearIndices(reverse(_size(P)))[reverse(index_tuple)...]
-    return ind
+    return to_manhattan_index(findindex.(values.(_sectors(I)), Tuple(c)), _size(P))
 end
 
 function Base.iterate(P::SectorValues{I}, i = 1) where {I <: ProductSector}
@@ -244,15 +248,11 @@ Base.hash(p::ProductSector, h::UInt) = hash(p.sectors, h)
 function Base.isless(a::I, b::I) where {I <: ProductSector}
     I1 = findindex.(values.(_sectors(I)), a.sectors)
     I2 = findindex.(values.(_sectors(I)), b.sectors)
-    if Base.IteratorSize(values(I)) === Base.IsInfinite()
-        d1 = sum(I1) - length(I1)
-        d2 = sum(I2) - length(I2)
-        d1 < d2 && return true
-        d1 > d2 && return false
-        return isless(I1, I2)
-    else
-        return isless(I1, I2)
-    end
+    d1 = sum(I1) - length(I1)
+    d2 = sum(I2) - length(I2)
+    d1 < d2 && return true
+    d1 > d2 && return false
+    return isless(I1, I2)
 end
 
 # Default construction from tensor product of sectors

--- a/src/product.jl
+++ b/src/product.jl
@@ -215,9 +215,9 @@ function anyonindex(a::ProductSector{T}) where {T}
     return LinearIndices(reverse(sizetuple))[reverse(index_tuple)...]
 end
 
-function Tvector(::Type{ProductSector{T}}) where {T}
+function Tmatrix(::Type{ProductSector{T}}) where {T}
     sector_tuple = Base.fieldtypes(T)
-    return kron(map(Tvector, sector_tuple)...)
+    return kron(map(Tmatrix, sector_tuple)...)
 end
 
 function Smatrix(::Type{ProductSector{T}}) where {T}

--- a/src/product.jl
+++ b/src/product.jl
@@ -225,6 +225,22 @@ function Smatrix(::Type{ProductSector{T}}) where {T}
     return kron(map(Smatrix, sector_tuple)...)
 end
 
+function sqdim(::Type{ProductSector{T}}) where {T}
+    return *(sqdim.(Base.fieldtypes(T))...)
+end
+
+function topological_central_charge(::Type{ProductSector{T}}) where {T}
+    c_tot = mod(sum(topological_central_charge.(Base.fieldtypes(T))) + 4, 8) - 4
+    if c_tot == -4 // 1
+        return 4 // 1
+    end
+    return c_tot
+end
+
+function ismodular(::Type{ProductSector{T}}) where {T}
+    return all(ismodular, Base.fieldtypes(T))
+end
+
 function fusiontensor(a::I, b::I, c::I) where {I <: ProductSector}
     return _kron(
         fusiontensor(map(_firstsector, (a, b, c))...),

--- a/src/product.jl
+++ b/src/product.jl
@@ -206,12 +206,12 @@ function anyonbasis(::Type{ProductSector{T}}, i::Int) where {T}
     return ProductSector{T}(anyontuple...)
 end
 
-function anyonindex(::Type{ProductSector{T}}, a::ProductSector{T}) where {T}
+function anyonindex(a::ProductSector{T}) where {T}
     Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     sectortuple = Base.fieldtypes(T)
     sizetuple = map(s -> _length(values(s)), sectortuple)
-    index_tuple = map(x -> anyonindex(x...), zip(sectortuple, Tuple(a)))
+    index_tuple = map(anyonindex, Tuple(a))
     return LinearIndices(reverse(sizetuple))[reverse(index_tuple)...]
 end
 

--- a/src/product.jl
+++ b/src/product.jl
@@ -196,37 +196,6 @@ end
 frobenius_schur_phase(p::ProductSector) = prod(frobenius_schur_phase, p.sectors)
 frobenius_schur_indicator(p::ProductSector) = prod(frobenius_schur_indicator, p.sectors)
 
-function Tmatrix(::Type{I}) where {I <: ProductSector}
-    sector_tuple = _sectors(I)
-    matrices = Tmatrix.(sector_tuple)
-    Tvector = ones(braidingscalartype(I), length(values(I)))
-    for (ia, a) in enumerate(values(I))
-        for (i_anyon_component, anyon_component) in enumerate(a)
-            matrix_component = matrices[i_anyon_component]
-            sector_component = sector_tuple[i_anyon_component]
-            index_component = findindex(values(sector_component), anyon_component)
-            Tvector[ia] *= matrix_component[index_component, index_component]
-        end
-    end
-    return Diagonal(Tvector)
-end
-
-function Smatrix(::Type{I}) where {I <: ProductSector}
-    sector_tuple = _sectors(I)
-    matrices = Smatrix.(sector_tuple)
-    S_matrix = ones(braidingscalartype(I), length(values(I)), length(values(I)))
-    for (ia, a) in enumerate(values(I)), (ib, b) in enumerate(values(I))
-        for (i_anyon_component, (a_anyon_component, b_anyon_component)) in enumerate(zip(a, b))
-            matrix_component = matrices[i_anyon_component]
-            sector_this_component = sector_tuple[i_anyon_component]
-            index_a_component = findindex(values(sector_this_component), a_anyon_component)
-            index_b_component = findindex(values(sector_this_component), b_anyon_component)
-            S_matrix[ia, ib] *= matrix_component[index_a_component, index_b_component]
-        end
-    end
-    return S_matrix
-end
-
 function sqdim(::Type{I}) where {I <: ProductSector}
     return *(sqdim.(_sectors(I))...)
 end

--- a/src/product.jl
+++ b/src/product.jl
@@ -26,8 +26,7 @@ _sectors(::Type{ProductSector{T}}) where {T} = Base.fieldtypes(T)
 _sectors(::Type) = error("should never be reached") # keeps JET happy
 
 function _kron_iter(::Type{ProductSector{T}}) where {T} # Construct an iterator with the same order as the Kronecker product.
-    sector_tuple = Base.fieldtypes(T)
-    tuple_iterators = values.(sector_tuple)
+    tuple_iterators = values.(_sectors(T))
     @assert !any(it -> Base.IteratorSize(it) isa Base.IsInfinite, tuple_iterators) "All sectors need to be finite"
     return (ProductSector{T}(reverse(x)) for x in Iterators.product(reverse(tuple_iterators)...))
 end

--- a/src/product.jl
+++ b/src/product.jl
@@ -227,17 +227,24 @@ function sqdim(::Type{I}) where {I <: ProductSector}
     return *(sqdim.(_sectors(I))...)
 end
 
-function topological_central_charge(::Type{I}) where {I <: ProductSector}
-    c_tot = mod(sum(topological_central_charge.(_sectors(I))) + 4, 8) - 4
+function topological_spin(p::ProductSector; tol = 1.0e-12)
+    tot_spin = mod(sum(map(x -> topological_spin(x; tol = tol), p.sectors)) + 1 // 2, 1) - 1 // 2
+    if tot_spin == -1 // 2
+        return 1 // 2
+    end
+    return tot_spin
+end
+
+function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: ProductSector}
+    c_tot = mod(sum(map(x -> topological_central_charge(x; tol = tol), _sectors(I))) + 4, 8) - 4
     if c_tot == -4 // 1
         return 4 // 1
     end
     return c_tot
 end
 
-function ismodular(::Type{I}) where {I <: ProductSector}
-    return all(ismodular, _sectors(I))
-end
+ismodular(::Type{I}; tol = 1.0e-12) where {I <: ProductSector} = all(P -> ismodular(P; tol = tol), _sectors(I))
+istransparent(p::ProductSector; tol = 1.0e-12) = all(a -> istransparent(a; tol = tol), p.sectors)
 
 function fusiontensor(a::I, b::I, c::I) where {I <: ProductSector}
     return _kron(
@@ -279,6 +286,8 @@ end
 fermionparity(p::ProductSector) = mapreduce(fermionparity, xor, p.sectors)
 
 dim(p::ProductSector) = *(dim.(p.sectors)...)
+twist(p::ProductSector) = *(twist.(p.sectors)...)
+hopflink(p::I, q::I) where {I <: ProductSector} = *(map(x -> hopflink(x...), zip(p.sectors, q.sectors))...)
 
 Base.isequal(p1::ProductSector, p2::ProductSector) = isequal(p1.sectors, p2.sectors)
 Base.hash(p::ProductSector, h::UInt) = hash(p.sectors, h)

--- a/src/product.jl
+++ b/src/product.jl
@@ -26,7 +26,7 @@ _sectors(::Type{ProductSector{T}}) where {T} = Base.fieldtypes(T)
 _sectors(::Type) = error("should never be reached") # keeps JET happy
 
 function _kron_iter(::Type{ProductSector{T}}) where {T} # Construct an iterator with the same order as the Kronecker product.
-    tuple_iterators = values.(_sectors(T))
+    tuple_iterators = values.(Base.fieldtypes(T))
     @assert !any(it -> Base.IteratorSize(it) isa Base.IsInfinite, tuple_iterators) "All sectors need to be finite"
     return (ProductSector{T}(reverse(x)) for x in Iterators.product(reverse(tuple_iterators)...))
 end

--- a/src/product.jl
+++ b/src/product.jl
@@ -25,34 +25,6 @@ Base.indexed_iterate(s::ProductSector, args...) = Base.indexed_iterate(s.sectors
 _sectors(::Type{ProductSector{T}}) where {T} = Base.fieldtypes(T)
 _sectors(::Type) = error("should never be reached") # keeps JET happy
 
-function anyonbasis(::Type{I}, i::Int) where {I <: Sector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return values(I)[i]
-end
-function anyonbasis(::Type{ProductSector{T}}, i::Int) where {T}
-    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    sectortuple = Base.fieldtypes(T)
-    sizetuple = map(s -> _length(values(s)), sectortuple)
-    indextuple = reverse(Tuple(CartesianIndices(reverse(sizetuple))[i]))
-    anyontuple = map(x -> anyonbasis(x...), zip(sectortuple, indextuple))
-    return ProductSector{T}(anyontuple...)
-end
-function anyonindex(::Type{I}, a::I) where {I <: Sector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return findindex(values(I), a)
-end
-function anyonindex(::Type{ProductSector{T}}, a::ProductSector{T}) where {T}
-    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    sectortuple = Base.fieldtypes(T)
-    sizetuple = map(s -> _length(values(s)), sectortuple)
-    index_tuple = map(x -> anyonindex(x...), zip(sectortuple, Tuple(a)))
-    return LinearIndices(reverse(sizetuple))[reverse(index_tuple)...]
-end
-
 function Base.IteratorSize(::Type{SectorValues{I}}) where {I <: ProductSector}
     return Base.IteratorSize(Base.Iterators.product(map(values, _sectors(I))...))
 end
@@ -223,6 +195,35 @@ end
 
 frobenius_schur_phase(p::ProductSector) = prod(frobenius_schur_phase, p.sectors)
 frobenius_schur_indicator(p::ProductSector) = prod(frobenius_schur_indicator, p.sectors)
+
+function anyonbasis(::Type{ProductSector{T}}, i::Int) where {T}
+    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    sectortuple = Base.fieldtypes(T)
+    sizetuple = map(s -> _length(values(s)), sectortuple)
+    indextuple = reverse(Tuple(CartesianIndices(reverse(sizetuple))[i]))
+    anyontuple = map(x -> anyonbasis(x...), zip(sectortuple, indextuple))
+    return ProductSector{T}(anyontuple...)
+end
+
+function anyonindex(::Type{ProductSector{T}}, a::ProductSector{T}) where {T}
+    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    sectortuple = Base.fieldtypes(T)
+    sizetuple = map(s -> _length(values(s)), sectortuple)
+    index_tuple = map(x -> anyonindex(x...), zip(sectortuple, Tuple(a)))
+    return LinearIndices(reverse(sizetuple))[reverse(index_tuple)...]
+end
+
+function Tvector(::Type{ProductSector{T}}) where {T}
+    sector_tuple = Base.fieldtypes(T)
+    return kron(map(Tvector, sector_tuple)...)
+end
+
+function Smatrix(::Type{ProductSector{T}}) where {T}
+    sector_tuple = Base.fieldtypes(T)
+    return kron(map(Smatrix, sector_tuple)...)
+end
 
 function fusiontensor(a::I, b::I, c::I) where {I <: ProductSector}
     return _kron(

--- a/src/product.jl
+++ b/src/product.jl
@@ -196,31 +196,35 @@ end
 frobenius_schur_phase(p::ProductSector) = prod(frobenius_schur_phase, p.sectors)
 frobenius_schur_indicator(p::ProductSector) = prod(frobenius_schur_indicator, p.sectors)
 
-function anyonbasis(::Type{I}, i::Int) where {I <: ProductSector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    sectortuple = _sectors(I)
-    sizetuple = map(s -> _length(values(s)), sectortuple)
-    indextuple = reverse(Tuple(CartesianIndices(reverse(sizetuple))[i]))
-    anyontuple = map(x -> anyonbasis(x...), zip(sectortuple, indextuple))
-    return I(anyontuple...)
-end
-
-function anyonindex(a::I) where {I <: ProductSector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    sectortuple = _sectors(I)
-    sizetuple = map(s -> _length(values(s)), sectortuple)
-    index_tuple = map(anyonindex, Tuple(a))
-    return LinearIndices(reverse(sizetuple))[reverse(index_tuple)...]
-end
-
 function Tmatrix(::Type{I}) where {I <: ProductSector}
-    return kron(map(Tmatrix, _sectors(I))...)
+    sector_tuple = _sectors(I)
+    matrices = Tmatrix.(sector_tuple)
+    Tvector = ones(braidingscalartype(I), length(values(I)))
+    for (ia, a) in enumerate(values(I))
+        for (i_anyon_component, anyon_component) in enumerate(a)
+            matrix_component = matrices[i_anyon_component]
+            sector_component = sector_tuple[i_anyon_component]
+            index_component = findindex(values(sector_component), anyon_component)
+            Tvector[ia] *= matrix_component[index_component, index_component]
+        end
+    end
+    return Diagonal(Tvector)
 end
 
 function Smatrix(::Type{I}) where {I <: ProductSector}
-    return kron(map(Smatrix, _sectors(I))...)
+    sector_tuple = _sectors(I)
+    matrices = Smatrix.(sector_tuple)
+    S_matrix = ones(braidingscalartype(I), length(values(I)), length(values(I)))
+    for (ia, a) in enumerate(values(I)), (ib, b) in enumerate(values(I))
+        for (i_anyon_component, (a_anyon_component, b_anyon_component)) in enumerate(zip(a, b))
+            matrix_component = matrices[i_anyon_component]
+            sector_this_component = sector_tuple[i_anyon_component]
+            index_a_component = findindex(values(sector_this_component), a_anyon_component)
+            index_b_component = findindex(values(sector_this_component), b_anyon_component)
+            S_matrix[ia, ib] *= matrix_component[index_a_component, index_b_component]
+        end
+    end
+    return S_matrix
 end
 
 function sqdim(::Type{I}) where {I <: ProductSector}

--- a/src/product.jl
+++ b/src/product.jl
@@ -196,49 +196,47 @@ end
 frobenius_schur_phase(p::ProductSector) = prod(frobenius_schur_phase, p.sectors)
 frobenius_schur_indicator(p::ProductSector) = prod(frobenius_schur_indicator, p.sectors)
 
-function anyonbasis(::Type{ProductSector{T}}, i::Int) where {T}
-    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
+function anyonbasis(::Type{I}, i::Int) where {I <: ProductSector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    sectortuple = Base.fieldtypes(T)
+    sectortuple = _sectors(I)
     sizetuple = map(s -> _length(values(s)), sectortuple)
     indextuple = reverse(Tuple(CartesianIndices(reverse(sizetuple))[i]))
     anyontuple = map(x -> anyonbasis(x...), zip(sectortuple, indextuple))
-    return ProductSector{T}(anyontuple...)
+    return I(anyontuple...)
 end
 
-function anyonindex(a::ProductSector{T}) where {T}
-    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
+function anyonindex(a::I) where {I <: ProductSector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    sectortuple = Base.fieldtypes(T)
+    sectortuple = _sectors(I)
     sizetuple = map(s -> _length(values(s)), sectortuple)
     index_tuple = map(anyonindex, Tuple(a))
     return LinearIndices(reverse(sizetuple))[reverse(index_tuple)...]
 end
 
-function Tmatrix(::Type{ProductSector{T}}) where {T}
-    sector_tuple = Base.fieldtypes(T)
-    return kron(map(Tmatrix, sector_tuple)...)
+function Tmatrix(::Type{I}) where {I <: ProductSector}
+    return kron(map(Tmatrix, _sectors(I))...)
 end
 
-function Smatrix(::Type{ProductSector{T}}) where {T}
-    sector_tuple = Base.fieldtypes(T)
-    return kron(map(Smatrix, sector_tuple)...)
+function Smatrix(::Type{I}) where {I <: ProductSector}
+    return kron(map(Smatrix, _sectors(I))...)
 end
 
-function sqdim(::Type{ProductSector{T}}) where {T}
-    return *(sqdim.(Base.fieldtypes(T))...)
+function sqdim(::Type{I}) where {I <: ProductSector}
+    return *(sqdim.(_sectors(I))...)
 end
 
-function topological_central_charge(::Type{ProductSector{T}}) where {T}
-    c_tot = mod(sum(topological_central_charge.(Base.fieldtypes(T))) + 4, 8) - 4
+function topological_central_charge(::Type{I}) where {I <: ProductSector}
+    c_tot = mod(sum(topological_central_charge.(_sectors(I))) + 4, 8) - 4
     if c_tot == -4 // 1
         return 4 // 1
     end
     return c_tot
 end
 
-function ismodular(::Type{ProductSector{T}}) where {T}
-    return all(ismodular, Base.fieldtypes(T))
+function ismodular(::Type{I}) where {I <: ProductSector}
+    return all(ismodular, _sectors(I))
 end
 
 function fusiontensor(a::I, b::I, c::I) where {I <: ProductSector}

--- a/src/product.jl
+++ b/src/product.jl
@@ -25,12 +25,6 @@ Base.indexed_iterate(s::ProductSector, args...) = Base.indexed_iterate(s.sectors
 _sectors(::Type{ProductSector{T}}) where {T} = Base.fieldtypes(T)
 _sectors(::Type) = error("should never be reached") # keeps JET happy
 
-function _kron_iter(::Type{ProductSector{T}}) where {T} # Construct an iterator with the same order as the Kronecker product.
-    tuple_iterators = values.(Base.fieldtypes(T))
-    @assert !any(it -> Base.IteratorSize(it) isa Base.IsInfinite, tuple_iterators) "All sectors need to be finite"
-    return (ProductSector{T}(reverse(x)) for x in Iterators.product(reverse(tuple_iterators)...))
-end
-
 function Base.IteratorSize(::Type{SectorValues{I}}) where {I <: ProductSector}
     return Base.IteratorSize(Base.Iterators.product(map(values, _sectors(I))...))
 end
@@ -46,11 +40,13 @@ function _size(::SectorValues{I}) where {I <: ProductSector}
     return map(s -> _length(values(s)), _sectors(I))
 end
 function Base.getindex(P::SectorValues{I}, i::Int) where {I <: ProductSector}
-    inds = manhattan_to_multidimensional_index(i, _size(P))
+    inds = Base.IteratorSize(P) === Base.IsInfinite() ? manhattan_to_multidimensional_index(i, _size(P)) : reverse(Tuple(CartesianIndices(reverse(_size(P)))[i]))
     return I(getindex.(values.(_sectors(I)), inds))
 end
 function findindex(P::SectorValues{I}, c::I) where {I <: ProductSector}
-    return to_manhattan_index(findindex.(values.(_sectors(I)), Tuple(c)), _size(P))
+    index_tuple = findindex.(values.(_sectors(I)), Tuple(c))
+    ind = Base.IteratorSize(P) === Base.IsInfinite() ? to_manhattan_index(index_tuple, _size(P)) : LinearIndices(reverse(_size(P)))[reverse(index_tuple)...]
+    return ind
 end
 
 function Base.iterate(P::SectorValues{I}, i = 1) where {I <: ProductSector}
@@ -248,11 +244,15 @@ Base.hash(p::ProductSector, h::UInt) = hash(p.sectors, h)
 function Base.isless(a::I, b::I) where {I <: ProductSector}
     I1 = findindex.(values.(_sectors(I)), a.sectors)
     I2 = findindex.(values.(_sectors(I)), b.sectors)
-    d1 = sum(I1) - length(I1)
-    d2 = sum(I2) - length(I2)
-    d1 < d2 && return true
-    d1 > d2 && return false
-    return isless(I1, I2)
+    if Base.IteratorSize(values(I)) === Base.IsInfinite()
+        d1 = sum(I1) - length(I1)
+        d2 = sum(I2) - length(I2)
+        d1 < d2 && return true
+        d1 > d2 && return false
+        return isless(I1, I2)
+    else
+        return isless(I1, I2)
+    end
 end
 
 # Default construction from tensor product of sectors

--- a/src/product.jl
+++ b/src/product.jl
@@ -25,6 +25,13 @@ Base.indexed_iterate(s::ProductSector, args...) = Base.indexed_iterate(s.sectors
 _sectors(::Type{ProductSector{T}}) where {T} = Base.fieldtypes(T)
 _sectors(::Type) = error("should never be reached") # keeps JET happy
 
+function _kron_iter(::Type{ProductSector{T}}) where {T} # Construct an iterator with the same order as the Kronecker product.
+    sector_tuple = Base.fieldtypes(T)
+    tuple_iterators = values.(sector_tuple)
+    @assert !any(it -> Base.IteratorSize(it) isa Base.IsInfinite, tuple_iterators) "All sectors need to be finite"
+    return (ProductSector{T}(reverse(x)) for x in Iterators.product(reverse(tuple_iterators)...))
+end
+
 function Base.IteratorSize(::Type{SectorValues{I}}) where {I <: ProductSector}
     return Base.IteratorSize(Base.Iterators.product(map(values, _sectors(I))...))
 end

--- a/src/product.jl
+++ b/src/product.jl
@@ -196,29 +196,6 @@ end
 frobenius_schur_phase(p::ProductSector) = prod(frobenius_schur_phase, p.sectors)
 frobenius_schur_indicator(p::ProductSector) = prod(frobenius_schur_indicator, p.sectors)
 
-function sqdim(::Type{I}) where {I <: ProductSector}
-    return *(sqdim.(_sectors(I))...)
-end
-
-function topological_spin(p::ProductSector; tol = 1.0e-12)
-    tot_spin = mod(sum(map(x -> topological_spin(x; tol = tol), p.sectors)) + 1 // 2, 1) - 1 // 2
-    if tot_spin == -1 // 2
-        return 1 // 2
-    end
-    return tot_spin
-end
-
-function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: ProductSector}
-    c_tot = mod(sum(map(x -> topological_central_charge(x; tol = tol), _sectors(I))) + 4, 8) - 4
-    if c_tot == -4 // 1
-        return 4 // 1
-    end
-    return c_tot
-end
-
-ismodular(::Type{I}; tol = 1.0e-12) where {I <: ProductSector} = all(P -> ismodular(P; tol = tol), _sectors(I))
-istransparent(p::ProductSector; tol = 1.0e-12) = all(a -> istransparent(a; tol = tol), p.sectors)
-
 function fusiontensor(a::I, b::I, c::I) where {I <: ProductSector}
     return _kron(
         fusiontensor(map(_firstsector, (a, b, c))...),

--- a/src/product.jl
+++ b/src/product.jl
@@ -25,10 +25,32 @@ Base.indexed_iterate(s::ProductSector, args...) = Base.indexed_iterate(s.sectors
 _sectors(::Type{ProductSector{T}}) where {T} = Base.fieldtypes(T)
 _sectors(::Type) = error("should never be reached") # keeps JET happy
 
-function _kron_iter(::Type{ProductSector{T}}) where {T} # Construct an iterator with the same order as the Kronecker product.
-    tuple_iterators = values.(Base.fieldtypes(T))
-    @assert !any(it -> Base.IteratorSize(it) isa Base.IsInfinite, tuple_iterators) "All sectors need to be finite"
-    return (ProductSector{T}(reverse(x)) for x in Iterators.product(reverse(tuple_iterators)...))
+function anyonbasis(::Type{I}, i::Int) where {I <: Sector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return values(I)[i]
+end
+function anyonbasis(::Type{ProductSector{T}}, i::Int) where {T}
+    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    sectortuple = Base.fieldtypes(T)
+    sizetuple = map(s -> _length(values(s)), sectortuple)
+    indextuple = reverse(Tuple(CartesianIndices(reverse(sizetuple))[i]))
+    anyontuple = map(x -> anyonbasis(x...), zip(sectortuple, indextuple))
+    return ProductSector{T}(anyontuple...)
+end
+function anyonindex(::Type{I}, a::I) where {I <: Sector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return findindex(values(I), a)
+end
+function anyonindex(::Type{ProductSector{T}}, a::ProductSector{T}) where {T}
+    Base.IteratorSize(values(ProductSector{T})) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    sectortuple = Base.fieldtypes(T)
+    sizetuple = map(s -> _length(values(s)), sectortuple)
+    index_tuple = map(x -> anyonindex(x...), zip(sectortuple, Tuple(a)))
+    return LinearIndices(reverse(sizetuple))[reverse(index_tuple)...]
 end
 
 function Base.IteratorSize(::Type{SectorValues{I}}) where {I <: ProductSector}

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -653,7 +653,8 @@ Return the T-vector of the sector type `I`, which is a vector containing the twi
 function Tvector(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return reshape([twist(a) for a in values(I)], (length(values(I)),))
+    vals = values(I)
+    return [twist(a) for a in vals]
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -647,11 +647,11 @@ twist(a::Sector) = twist_from_Rsymbol(a)
 twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b in a ⊗ a)
 
 """
-    spin_top(a::Sector; tol=1e-12)
+    topological_spin(a::Sector; tol=1e-12)
 
 Return the topological spin of a sector `a`. Here we assume the range of the output as rational numbers within (-1 / 2, 1 / 2].
 """
-function spin_top(a::Sector; tol = 1.0e-12)
+function topological_spin(a::Sector; tol = 1.0e-12)
     s = angle(twist(a)) / (2π)
     s = mod(s, 1)
     if s > 0.5
@@ -728,11 +728,11 @@ function Smatrix(::Type{I}) where {I <: Sector}
 end
 
 """
-    c_top(::Type{I}) where {I <: Sector}
-Return the topological central charge c_top of the modular sector type `I`, where `c_top` is determined mod 8.
+    topological_central_charge(::Type{I}) where {I <: Sector}
+Return the topological central charge topological_central_charge of the modular sector type `I`, where `topological_central_charge` is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
-function c_top(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
     ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
     ϕ = angle(ξ) * 8 / 2pi
     c_float = mod(ϕ, 8)

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -667,13 +667,17 @@ For ProductSector I ⊠ J, we have Tvector(I ⊠ J) == kron(Tvector(I), Tvector(
 function Tvector(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
+    vals = values(I)
     T = zeros(braidingscalartype(I), length(vals))
     @inbounds for (ia, a) in enumerate(vals)
         T[ia] = twist(a)
     end
 
     return T
+end
+function Tvector(::Type{ProductSector{T}}) where {T}
+    sector_tuple = Base.fieldtypes(T)
+    return kron(map(Tvector, sector_tuple)...)
 end
 
 """
@@ -701,13 +705,17 @@ For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
+    vals = values(I)
     S = zeros(braidingscalartype(I), length(vals), length(vals))
     @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
         S[ia, ib] = hopflink(a, b) # Normalized by total quantum dimension will change the data type of the S-matrix.
     end
 
     return S
+end
+function Smatrix(::Type{ProductSector{T}}) where {T}
+    sector_tuple = Base.fieldtypes(T)
+    return kron(map(Smatrix, sector_tuple)...)
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -650,7 +650,11 @@ twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b
     Tvector(::Type{I}) where {I <: Sector}
 Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
 """
-Tvector(::Type{I}) where {I <: Sector} = reshape([twist(a) for a in values(I)], (length(values(I)),))
+function Tvector(::Type{I}) where {I <: Sector}
+    Base.IteratorSize(values(I)) === Base.HasLength() ||
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return reshape([twist(a) for a in values(I)], (length(values(I)),))
+end
 
 """
     dim(::Type{I}) where {I <: Sector}
@@ -658,7 +662,7 @@ Return the total quantum dimension D of the sector type `I`, which is defined as
 """
 function dim(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) === Base.HasLength() ||
-    throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return sqrt(sum(dim(b)^2 for b in values(I)))
 end
 
@@ -672,7 +676,11 @@ hopflink(a::Sector, b::Sector) = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a
      Smatrix(::Type{I}) where {I <: Sector}
 Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`, normalized by the total quantum dimension of `I`.
 """
-Smatrix(::Type{I}) where {I <: Sector} = reshape([hopflink(a, b) for a in values(I), b in values(I)], (length(values(I)), length(values(I)))) / dim(I)
+function Smatrix(::Type{I}) where {I <: Sector}
+    Base.IteratorSize(values(I)) === Base.HasLength() ||
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return reshape([hopflink(a, b) for a in values(I), b in values(I)], (length(values(I)), length(values(I)))) / dim(I)
+end
 
 """
     ξ(::Type{I}) where {I <: Sector}

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -709,11 +709,11 @@ function Smatrix(::Type{I}) where {I <: Sector}
 end
 
 """
-    ξ(::Type{I}) where {I <: Sector}
-Return the topological central charge `ξ` of the modular sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I` weighted by their twists, divided by the total quantum dimension of `I`.
-Satisfying the relation `ξ = exp(2πi c / 8)` where `c` is the chiral central charge of the corresponding topological phase.
+    topological_central_charge(::Type{I}) where {I <: Sector}
+Return the topological central charge of the modular sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I` weighted by their twists, divided by the total quantum dimension of `I`.
+Satisfying the relation `topological_central_charge(I) == exp(2πi c / 8)` where `c` is the chiral central charge mod 8 of the corresponding topological phase.
 """
-ξ(::Type{I}) where {I <: Sector} = sum(dim(a)^2 * twist(a) for a in values(I)) / dim(I)
+topological_central_charge(::Type{I}) where {I <: Sector} = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
 
 # Operations between sectors of different types
 # ------------------------------------------------------------------------------

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -648,6 +648,7 @@ twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b
 
 """
     Tvector(::Type{I}) where {I <: Sector}
+
 Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
 """
 function Tvector(::Type{I}) where {I <: Sector}

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -683,7 +683,7 @@ function dim(::Type{I}) where {I <: Sector}
 end
 
 """
-   hopflink(a::Sector, b::Sector)
+   hopflink(a::I, b::I) where {I <: Sector}
 
 Return the hopflink of sectors `a` and `b`, which is defined as the trace of the double braiding between `a` and `b`.
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -647,18 +647,15 @@ twist(a::Sector) = twist_from_Rsymbol(a)
 twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b in a ⊗ a)
 
 """
-    topological_spin(a::Sector; tol = nothing)
+    topological_spin(a::Sector)
 
 Return the topological spin of a sector `a`. Here we assume the range of the output as rational numbers within (-1 / 2, 1 / 2].
 """
-function topological_spin(a::Sector; tol = nothing)
+function topological_spin(a::Sector)
     s = angle(twist(a)) / 2pi
     isapprox(s, -0.5) && return 1 // 2
-
-    if tol === nothing
-        T = real(typeof(s))
-        tol = sqrt(eps(T))
-    end
+    T = real(typeof(s))
+    tol = sqrt(eps(T))
     return rationalize(s; tol = tol) # rationalize uses tol = eps, whose default is too low to extract useful data.
 end
 
@@ -717,22 +714,20 @@ function ismodular(::Type{II}; kwargs...) where {II <: Sector}
 end
 
 """
-    topological_central_charge(::Type{I}; tol = nothing) where {I <: Sector}
+    topological_central_charge(::Type{I}) where {I <: Sector}
 
 Return the topological central charge c of the modular sector type `I`, where c is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
-function topological_central_charge(::Type{I}; tol = nothing) where {I <: Sector}
+function topological_central_charge(::Type{I}) where {I <: Sector}
     ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / dim(I)
     @assert isapprox(abs(ξ), 1) "Sector $I is not modular"
     c_float = angle(ξ) * 8 / (2π)
 
     isapprox(c_float, -4) && return 4 // 1
 
-    if tol === nothing
-        T = real(typeof(c_float))
-        tol = sqrt(eps(T))
-    end
+    T = real(typeof(c_float))
+    tol = sqrt(eps(T))
 
     return rationalize(c_float; tol = tol) # rationalize uses tol = eps, whose default is too low to extract useful data.
 end

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -651,7 +651,7 @@ twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b
 Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
 """
 function Tvector(::Type{I}) where {I <: Sector}
-    Base.IteratorSize(values(I)) === Base.HasLength() ||
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return reshape([twist(a) for a in values(I)], (length(values(I)),))
 end
@@ -661,7 +661,7 @@ end
 Return the total quantum dimension D of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
 function dim(::Type{I}) where {I <: Sector}
-    Base.IteratorSize(values(I)) === Base.HasLength() ||
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return sqrt(sum(dim(b)^2 for b in values(I)))
 end
@@ -677,7 +677,7 @@ hopflink(a::Sector, b::Sector) = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a
 Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`, normalized by the total quantum dimension of `I`.
 """
 function Smatrix(::Type{I}) where {I <: Sector}
-    Base.IteratorSize(values(I)) === Base.HasLength() ||
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return reshape([hopflink(a, b) for a in values(I), b in values(I)], (length(values(I)), length(values(I)))) / dim(I)
 end

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -667,7 +667,7 @@ For ProductSector I ⊠ J, we have Tvector(I ⊠ J) == kron(Tvector(I), Tvector(
 function Tvector(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
+    vals = values(I)
     T = zeros(braidingscalartype(I), length(vals))
     @inbounds for (ia, a) in enumerate(vals)
         T[ia] = twist(a)
@@ -701,7 +701,7 @@ For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
+    vals = values(I)
     S = zeros(braidingscalartype(I), length(vals), length(vals))
     @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
         S[ia, ib] = hopflink(a, b) # Normalized by total quantum dimension will change the data type of the S-matrix.

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -657,20 +657,7 @@ function topological_spin(a::Sector; tol = 1.0e-12)
     return rationalize(s; tol = tol)
 end
 
-function anyonbasis(::Type{I}, i::Int) where {I <: Sector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return values(I)[i]
-end
-function anyonbasis(::Type{I}) where {I <: Sector}
-    return [anyonbasis(I, i) for i in 1:length(values(I))]
-end
-
-function anyonindex(a::I) where {I <: Sector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return findindex(values(I), a)
-end
+anyonbasis(::Type{I}) where {I <: Sector} = vec(collect(values(I)))
 
 """
     Tmatrix(::Type{I}) where {I <: Sector}

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -650,12 +650,23 @@ twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b
     Tvector(::Type{I}) where {I <: Sector}
 
 Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
+For ProductSector I ⊠ J, we have Tvector(I ⊠ J) == kron(Tvector(I), Tvector(J))
 """
 function Tvector(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     vals = values(I)
-    return [twist(a) for a in vals]
+    T = zeros(braidingscalartype(I), length(vals))
+    @inbounds for (ia, a) in enumerate(vals)
+        T[ia] = twist(a)
+    end
+
+    if I <: ProductSector
+        perm = sortperm(vec(collect(values(I))); by = Tuple) # using Tuple order to restore tensor product basis
+        T = T[perm]
+    end
+
+    return T
 end
 
 """
@@ -676,17 +687,24 @@ hopflink(a::I, b::I) where {I <: Sector} = sum(dim(c) * tr(Rsymbol(a, b, c) * Rs
 
 """
      Smatrix(::Type{I}) where {I <: Sector}
-Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`, normalized by the total quantum dimension of `I`.
+Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`.
+The S-matrix is not normalized by the total quantum dimension here.
+For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(J))
 """
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     vals = values(I)
     S = zeros(braidingscalartype(I), length(vals), length(vals))
-    d = dim(I)
     @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
-        S[ia, ib] = hopflink(a, b) / d
+        S[ia, ib] = hopflink(a, b) # Normalized by total quantum dimension will change the data type of the S-matrix.
     end
+
+    if I <: ProductSector
+        perm = sortperm(vec(collect(values(I))); by = Tuple) # using Tuple order to restore tensor product basis
+        S = S[perm, perm]
+    end
+
     return S
 end
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -657,6 +657,17 @@ function topological_spin(a::Sector; tol = 1.0e-12)
     return rationalize(s; tol = tol)
 end
 
+function anyonbasis(::Type{I}, i::Int) where {I <: Sector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return values(I)[i]
+end
+
+function anyonindex(::Type{I}, a::I) where {I <: Sector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return findindex(values(I), a)
+end
 
 """
     Tvector(::Type{I}) where {I <: Sector}
@@ -674,10 +685,6 @@ function Tvector(::Type{I}) where {I <: Sector}
     end
 
     return T
-end
-function Tvector(::Type{ProductSector{T}}) where {T}
-    sector_tuple = Base.fieldtypes(T)
-    return kron(map(Tvector, sector_tuple)...)
 end
 
 """
@@ -710,12 +717,7 @@ function Smatrix(::Type{I}) where {I <: Sector}
     @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
         S[ia, ib] = hopflink(a, b) # Normalized by total quantum dimension will change the data type of the S-matrix.
     end
-
     return S
-end
-function Smatrix(::Type{ProductSector{T}}) where {T}
-    sector_tuple = Base.fieldtypes(T)
-    return kron(map(Smatrix, sector_tuple)...)
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -670,13 +670,13 @@ function Tvector(::Type{I}) where {I <: Sector}
 end
 
 """
-    dim(::Type{I}) where {I <: Sector}
-Return the total quantum dimension D of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
+    sqDim(::Type{I}) where {I <: Sector}
+Return the square of total quantum dimension D² of the sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
-function dim(::Type{I}) where {I <: Sector}
+function sqDim(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return sqrt(sum(dim(b)^2 for b in values(I)))
+    return sum(dim(b)^2 for b in values(I))
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -732,13 +732,13 @@ function istransparent(a::I; tol = 1.0e-12) where {I <: Sector}
 end
 
 """
-    mugercenter(::Type{I}; tol = 1.0e-12) where {I <: Sector}
-Return a vector containing all simple objects in the Müger center of the sector `I`.
+    transparent_anyons(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+Return a vector containing all transparent anyons of the sector `I`.
 """
-function mugercenter(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+function transparent_anyons(::Type{I}; tol = 1.0e-12) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return collect(filter(a -> is_mugercentral(a; tol = tol), anyonbasis(I)))
+    return collect(filter(a -> istransparent(a; tol = tol), anyonbasis(I)))
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -652,16 +652,8 @@ twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b
 Return the topological spin of a sector `a`. Here we assume the range of the output as rational numbers within (-1 / 2, 1 / 2].
 """
 function topological_spin(a::Sector; tol = 1.0e-12)
-    s = angle(twist(a)) / (2π)
-    s = mod(s, 1)
-    if s > 0.5
-        s -= 1
-    end
-
-    if isapprox(abs(s), 0.5; atol = tol)
-        return 1 // 2
-    end
-
+    s = angle(twist(a)) / 2pi
+    isapprox(s, -0.5; atol = tol) && return 1 // 2
     return rationalize(s; tol = tol)
 end
 
@@ -725,15 +717,8 @@ We choose convention by restrict the returning value as rational numbers in (-4,
 """
 function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
     ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
-    ϕ = angle(ξ) * 8 / 2pi
-    c_float = mod(ϕ, 8)
-    if c_float > 4
-        c_float -= 8
-    end
-
-    if isapprox(abs(c_float), 4; atol = tol)
-        return 4 // 1
-    end
+    c_float = angle(ξ) * 8 / 2pi
+    isapprox(c_float, -4; atol = tol) && return 4 // 1
     return rationalize(c_float; tol = tol)
 end
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -654,17 +654,17 @@ dim(::Type{I}) where {I <: Sector} = sqrt(sum(dim(b)^2 for b in values(I)))
 
 """
     Smatrix(a::Sector, b::Sector)
-
 Return the S-matrix element `S_{ab}` of sectors `a` and `b`, which is defined as the trace of the double braiding between `a` and `b`.
 """
 Smatrix(a::Sector, b::Sector) = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a, c)) for c in a ⊗ b) / dim(typeof(a))
-Smatrix(::Type{I}) where {I <: Sector} = [Smatrix(a, b) for a in values(I), b in values(I)]
+Smatrix(::Type{I}) where {I <: Sector} = reshape([Smatrix(a, b) for a in values(I), b in values(I)], (length(values(I)), length(values(I))))
 
-function ismodular(::Type{I}) where {I <: Sector}
-    BraidingStyle(I) isa Anyonic() || return false
-    IsInfinite(I) && return false
-    return isunitary(Smatrix(I))
-end
+"""
+    ξ(::Type{I}) where {I <: Sector}
+Return the topological central charge `ξ` of the modular sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I` weighted by their twists, divided by the total quantum dimension of `I`.
+Satisfying the relation `ξ = exp(2πi c / 8)` where `c` is the chiral central charge of the corresponding topological phase.
+"""
+ξ(::Type{I}) where {I <: Sector} = sum(dim(a)^2 * twist(a) for a in values(I)) / dim(I)
 
 # Operations between sectors of different types
 # ------------------------------------------------------------------------------

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -656,7 +656,11 @@ Tvector(::Type{I}) where {I <: Sector} = reshape([twist(a) for a in values(I)], 
     dim(::Type{I}) where {I <: Sector}
 Return the total quantum dimension D of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
-dim(::Type{I}) where {I <: Sector} = sqrt(sum(dim(b)^2 for b in values(I)))
+function dim(::Type{I}) where {I <: Sector}
+    Base.IteratorSize(values(I)) === Base.HasLength() ||
+    throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return sqrt(sum(dim(b)^2 for b in values(I)))
+end
 
 """
    hopflink(a::Sector, b::Sector)

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -667,7 +667,7 @@ For ProductSector I ⊠ J, we have Tvector(I ⊠ J) == kron(Tvector(I), Tvector(
 function Tvector(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = values(I)
+    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
     T = zeros(braidingscalartype(I), length(vals))
     @inbounds for (ia, a) in enumerate(vals)
         T[ia] = twist(a)
@@ -701,7 +701,7 @@ For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = values(I)
+    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
     S = zeros(braidingscalartype(I), length(vals), length(vals))
     @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
         S[ia, ib] = hopflink(a, b) # Normalized by total quantum dimension will change the data type of the S-matrix.

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -647,7 +647,7 @@ twist(a::Sector) = twist_from_Rsymbol(a)
 twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b in a ⊗ a)
 
 """
-    topological_spin(a::Sector; tol=1e-12)
+    topological_spin(a::Sector; tol=1.0e-12)
 
 Return the topological spin of a sector `a`. Here we assume the range of the output as rational numbers within (-1 / 2, 1 / 2].
 """
@@ -662,6 +662,7 @@ function anyonbasis(::Type{I}, i::Int) where {I <: Sector}
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return values(I)[i]
 end
+function anyonbasis(::Type{I}) where {I <: Sector}
     return [anyonbasis(I, i) for i in 1:length(values(I))]
 end
 
@@ -684,6 +685,7 @@ function Tmatrix(::Type{I}) where {I <: Sector}
 end
 
 """
+    sqdim(::Type{I}) where {I <: Sector}
 Return the square of total quantum dimension D² of the sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
 function sqdim(::Type{I}) where {I <: Sector}
@@ -711,12 +713,13 @@ function Smatrix(::Type{I}) where {I <: Sector}
 end
 
 """
-    topological_central_charge(::Type{I}) where {I <: Sector}
-Return the topological central charge topological_central_charge of the modular sector type `I`, where `topological_central_charge` is determined mod 8.
+    topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+Return the topological central charge c of the modular sector type `I`, where c is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
 function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
     ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqdim(I))
+    @assert isapprox(abs(ξ), 1; atol = tol) "Sector $I is not modular"
     c_float = angle(ξ) * 8 / 2pi
     isapprox(c_float, -4; atol = tol) && return 4 // 1
     return rationalize(c_float; tol = tol)

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -703,7 +703,7 @@ end
 """
     ismodular(::Type{I}; tol = 1.0e-12) where {I <: Sector}
 
-Check whether a sector `I` is modular.
+Check whether a sector type `I` is modular.
 """
 function ismodular(::Type{II}; tol = 1.0e-12) where {II <: Sector}
     s = Smatrix(II)

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -646,6 +646,26 @@ Return the twist of a sector `a`.
 twist(a::Sector) = twist_from_Rsymbol(a)
 twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b in a ⊗ a)
 
+"""
+    dim(::Type{I}) where {I <: Sector}
+Return the total quantum dimension of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
+"""
+dim(::Type{I}) where {I <: Sector} = sqrt(sum(dim(b)^2 for b in values(I)))
+
+"""
+    Smatrix(a::Sector, b::Sector)
+
+Return the S-matrix element `S_{ab}` of sectors `a` and `b`, which is defined as the trace of the double braiding between `a` and `b`.
+"""
+Smatrix(a::Sector, b::Sector) = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a, c)) for c in a ⊗ b) / dim(typeof(a))
+Smatrix(::Type{I}) where {I <: Sector} = [Smatrix(a, b) for a in values(I), b in values(I)]
+
+function ismodular(::Type{I}) where {I <: Sector}
+    BraidingStyle(I) isa Anyonic() || return false
+    IsInfinite(I) && return false
+    return isunitary(Smatrix(I))
+end
+
 # Operations between sectors of different types
 # ------------------------------------------------------------------------------
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -663,7 +663,6 @@ anyonbasis(::Type{I}) where {I <: Sector} = vec(collect(values(I)))
     Tmatrix(::Type{I}) where {I <: Sector}
 
 Return the T-matrix of the sector type `I`, which is a diagonal matrix containing the twists of all sectors of type `I`.
-For ProductSector I ⊠ J, we have Tmatrix(I ⊠ J) == kron(Tmatrix(I), Tmatrix(J))
 """
 function Tmatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
@@ -673,6 +672,7 @@ end
 
 """
     sqdim(::Type{I}) where {I <: Sector}
+
 Return the square of total quantum dimension D² of the sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
 function sqdim(::Type{I}) where {I <: Sector}
@@ -683,29 +683,28 @@ end
 
 """
    hopflink(a::Sector, b::Sector)
+
 Return the hopflink of sectors `a` and `b`, which is defined as the trace of the double braiding between `a` and `b`.
 """
 hopflink(a::I, b::I) where {I <: Sector} = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a, c)) for c in a ⊗ b)
 
 """
      Smatrix(::Type{I}) where {I <: Sector}
+
 Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`.
 The S-matrix is not normalized by the total quantum dimension here.
-For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(J))
 """
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    val = values(I)
-    S = zeros(braidingscalartype(I), length(val), length(val))
-    for (ia, a) in enumerate(val), (ib, b) in enumerate(val)
-        S[ia, ib] = hopflink(a, b)
-    end
-    return S
+    vals = values(I)
+    l = length(vals)
+    return reshape([hopflink(a, b) for a in vals, b in vals], (l, l))
 end
 
 """
     ismodular(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+
 Check whether a sector `I` is modular.
 """
 function ismodular(::Type{II}; tol = 1.0e-12) where {II <: Sector}
@@ -715,6 +714,7 @@ end
 
 """
     istransparent(a::I; tol = 1.0e-12) where {I <: Sector}
+
 Check whether the object `a` is in the Müger center of sector `I`.
 """
 function istransparent(a::I; tol = 1.0e-12) where {I <: Sector}
@@ -725,7 +725,8 @@ end
 
 """
     transparent_anyons(::Type{I}; tol = 1.0e-12) where {I <: Sector}
-Return a vector containing all transparent anyons of the sector `I`.
+
+Return a vector containing all transparent anyons of the sector `I`, or all simple objects of the Müger center of the sector `I`.
 """
 function transparent_anyons(::Type{I}; tol = 1.0e-12) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
@@ -735,6 +736,7 @@ end
 
 """
     topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+
 Return the topological central charge c of the modular sector type `I`, where c is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -673,8 +673,7 @@ end
 """
     dim(::Type{I}) where {I <: Sector}
 
-Return the total quantum dimension D of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
-Or D = √∑d^2.
+Return the total quantum dimension D of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`, i.e. D = √(∑ₐ dₐ²).
 """
 function dim(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -647,17 +647,28 @@ twist(a::Sector) = twist_from_Rsymbol(a)
 twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b in a ⊗ a)
 
 """
+    Tvector(::Type{I}) where {I <: Sector}
+Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
+"""
+Tvector(::Type{I}) where {I <: Sector} = [twist(a) for a in values(I)]
+
+"""
     dim(::Type{I}) where {I <: Sector}
 Return the total quantum dimension of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
 dim(::Type{I}) where {I <: Sector} = sqrt(sum(dim(b)^2 for b in values(I)))
 
 """
-    Smatrix(a::Sector, b::Sector)
-Return the S-matrix element `S_{ab}` of sectors `a` and `b`, which is defined as the trace of the double braiding between `a` and `b`.
+   hopflink(a::Sector, b::Sector)
+Return the hopflink of sectors `a` and `b`, which is defined as the trace of the double braiding between `a` and `b`.
 """
-Smatrix(a::Sector, b::Sector) = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a, c)) for c in a ⊗ b) / dim(typeof(a))
-Smatrix(::Type{I}) where {I <: Sector} = reshape([Smatrix(a, b) for a in values(I), b in values(I)], (length(values(I)), length(values(I))))
+hopflink(a::Sector, b::Sector) = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a, c)) for c in a ⊗ b)
+
+"""
+     Smatrix(::Type{I}) where {I <: Sector}
+Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`, normalized by the total quantum dimension of `I`.
+"""
+Smatrix(::Type{I}) where {I <: Sector} = reshape([hopflink(a, b) for a in values(I), b in values(I)], (length(values(I)), length(values(I)))) / dim(I)
 
 """
     ξ(::Type{I}) where {I <: Sector}

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -662,6 +662,8 @@ function anyonbasis(::Type{I}, i::Int) where {I <: Sector}
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return values(I)[i]
 end
+    return [anyonbasis(I, i) for i in 1:length(values(I))]
+end
 
 function anyonindex(a::I) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
@@ -682,10 +684,9 @@ function Tmatrix(::Type{I}) where {I <: Sector}
 end
 
 """
-    sqDim(::Type{I}) where {I <: Sector}
 Return the square of total quantum dimension D² of the sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
-function sqDim(::Type{I}) where {I <: Sector}
+function sqdim(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return sum(dim(b)^2 for b in values(I))
@@ -715,7 +716,7 @@ Return the topological central charge topological_central_charge of the modular 
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
 function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
-    ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
+    ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqdim(I))
     c_float = angle(ξ) * 8 / 2pi
     isapprox(c_float, -4; atol = tol) && return 4 // 1
     return rationalize(c_float; tol = tol)

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -663,7 +663,7 @@ function anyonbasis(::Type{I}, i::Int) where {I <: Sector}
     return values(I)[i]
 end
 
-function anyonindex(::Type{I}, a::I) where {I <: Sector}
+function anyonindex(a::I) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     return findindex(values(I), a)
@@ -678,13 +678,7 @@ For ProductSector I ⊠ J, we have Tvector(I ⊠ J) == kron(Tvector(I), Tvector(
 function Tvector(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = values(I)
-    T = zeros(braidingscalartype(I), length(vals))
-    @inbounds for (ia, a) in enumerate(vals)
-        T[ia] = twist(a)
-    end
-
-    return T
+    return twist.(values(I))
 end
 
 """
@@ -712,12 +706,7 @@ For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = values(I)
-    S = zeros(braidingscalartype(I), length(vals), length(vals))
-    @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
-        S[ia, ib] = hopflink(a, b) # Normalized by total quantum dimension will change the data type of the S-matrix.
-    end
-    return S
+    return [hopflink(a, b) for a in values(I), b in values(I)]
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -647,14 +647,19 @@ twist(a::Sector) = twist_from_Rsymbol(a)
 twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b in a ⊗ a)
 
 """
-    topological_spin(a::Sector; tol=1.0e-12)
+    topological_spin(a::Sector; tol = nothing)
 
 Return the topological spin of a sector `a`. Here we assume the range of the output as rational numbers within (-1 / 2, 1 / 2].
 """
-function topological_spin(a::Sector; tol = 1.0e-12)
+function topological_spin(a::Sector; tol = nothing)
     s = angle(twist(a)) / 2pi
-    isapprox(s, -0.5; atol = tol) && return 1 // 2
-    return rationalize(s; tol = tol)
+    isapprox(s, -0.5) && return 1 // 2
+
+    if tol === nothing
+        T = real(typeof(s))
+        tol = sqrt(eps(T))
+    end
+    return rationalize(s; tol = tol) # rationalize uses tol = eps, whose default is too low to extract useful data.
 end
 
 """
@@ -669,14 +674,15 @@ function Tmatrix(::Type{I}) where {I <: Sector}
 end
 
 """
-    sqdim(::Type{I}) where {I <: Sector}
+    dim(::Type{I}) where {I <: Sector}
 
-Return the square of total quantum dimension D² of the sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I`.
+Return the total quantum dimension D of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
+Or D = √∑d^2.
 """
-function sqdim(::Type{I}) where {I <: Sector}
+function dim(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return sum(dim(b)^2 for b in values(I))
+    return sqrt(sum(dim(b)^2 for b in values(I)))
 end
 
 """
@@ -701,49 +707,34 @@ function Smatrix(::Type{I}) where {I <: Sector}
 end
 
 """
-    ismodular(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+    ismodular(::Type{I}; kwargs...) where {I <: Sector}
 
 Check whether a sector type `I` is modular.
 """
 function ismodular(::Type{II}; kwargs...) where {II <: Sector}
     s = Smatrix(II)
-    return isapprox(s' * s, sqdim(II) * I(size(s)[1]); kwargs...)
+    return isapprox(s' * s, dim(II)^2 * I(size(s)[1]); kwargs...)
 end
 
 """
-    istransparent(a::I; tol = 1.0e-12) where {I <: Sector}
-
-Check whether the object `a` is in the Müger center of sector `I`.
-"""
-function istransparent(a::I; tol = 1.0e-12) where {I <: Sector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return all(b -> isapprox(hopflink(a, b), dim(a) * dim(b); atol = tol), values(I))
-end
-
-"""
-    transparent_anyons(::Type{I}; tol = 1.0e-12) where {I <: Sector}
-
-Return a vector containing all transparent anyons of the sector `I`, or all simple objects of the Müger center of the sector `I`.
-"""
-function transparent_anyons(::Type{I}; tol = 1.0e-12) where {I <: Sector}
-    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
-        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return collect(filter(a -> istransparent(a; tol = tol), anyonbasis(I)))
-end
-
-"""
-    topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+    topological_central_charge(::Type{I}; tol = nothing) where {I <: Sector}
 
 Return the topological central charge c of the modular sector type `I`, where c is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
-function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
-    ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqdim(I))
-    @assert isapprox(abs(ξ), 1; atol = tol) "Sector $I is not modular"
-    c_float = angle(ξ) * 8 / 2pi
-    isapprox(c_float, -4; atol = tol) && return 4 // 1
-    return rationalize(c_float; tol = tol)
+function topological_central_charge(::Type{I}; tol = nothing) where {I <: Sector}
+    ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / dim(I)
+    @assert isapprox(abs(ξ), 1) "Sector $I is not modular"
+    c_float = angle(ξ) * 8 / (2π)
+
+    isapprox(c_float, -4) && return 4 // 1
+
+    if tol === nothing
+        T = real(typeof(c_float))
+        tol = sqrt(eps(T))
+    end
+
+    return rationalize(c_float; tol = tol) # rationalize uses tol = eps, whose default is too low to extract useful data.
 end
 
 # Operations between sectors of different types

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -650,11 +650,11 @@ twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b
     Tvector(::Type{I}) where {I <: Sector}
 Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
 """
-Tvector(::Type{I}) where {I <: Sector} = [twist(a) for a in values(I)]
+Tvector(::Type{I}) where {I <: Sector} = reshape([twist(a) for a in values(I)], (length(values(I)),))
 
 """
     dim(::Type{I}) where {I <: Sector}
-Return the total quantum dimension of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
+Return the total quantum dimension D of the sector type `I`, which is defined as the square root of the sum of the squares of the quantum dimensions of all sectors of type `I`.
 """
 dim(::Type{I}) where {I <: Sector} = sqrt(sum(dim(b)^2 for b in values(I)))
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -670,7 +670,7 @@ end
    hopflink(a::Sector, b::Sector)
 Return the hopflink of sectors `a` and `b`, which is defined as the trace of the double braiding between `a` and `b`.
 """
-hopflink(a::Sector, b::Sector) = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a, c)) for c in a ⊗ b)
+hopflink(a::I, b::I) where {I <: Sector} = sum(dim(c) * tr(Rsymbol(a, b, c) * Rsymbol(b, a, c)) for c in a ⊗ b)
 
 """
      Smatrix(::Type{I}) where {I <: Sector}

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -670,15 +670,15 @@ function anyonindex(a::I) where {I <: Sector}
 end
 
 """
-    Tvector(::Type{I}) where {I <: Sector}
+    Tmatrix(::Type{I}) where {I <: Sector}
 
-Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
-For ProductSector I ⊠ J, we have Tvector(I ⊠ J) == kron(Tvector(I), Tvector(J))
+Return the T-matrix of the sector type `I`, which is a diagonal matrix containing the twists of all sectors of type `I`.
+For ProductSector I ⊠ J, we have Tmatrix(I ⊠ J) == kron(Tmatrix(I), Tmatrix(J))
 """
-function Tvector(::Type{I}) where {I <: Sector}
+function Tmatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return twist.(values(I))
+    return Diagonal(twist.(values(I)))
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -659,11 +659,12 @@ function topological_spin(a::Sector; tol = 1.0e-12)
     end
 
     if isapprox(abs(s), 0.5; atol = tol)
-        return sign(s) * (1 // 2)
+        return 1 // 2
     end
 
     return rationalize(s; tol = tol)
 end
+
 
 """
     Tvector(::Type{I}) where {I <: Sector}
@@ -674,15 +675,10 @@ For ProductSector I ⊠ J, we have Tvector(I ⊠ J) == kron(Tvector(I), Tvector(
 function Tvector(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = values(I)
+    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
     T = zeros(braidingscalartype(I), length(vals))
     @inbounds for (ia, a) in enumerate(vals)
         T[ia] = twist(a)
-    end
-
-    if I <: ProductSector
-        perm = sortperm(vec(collect(values(I))); by = Tuple) # using Tuple order to restore tensor product basis
-        T = T[perm]
     end
 
     return T
@@ -713,15 +709,10 @@ For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    vals = values(I)
+    vals = (I <: ProductSector) ? _kron_iter(I) : values(I)
     S = zeros(braidingscalartype(I), length(vals), length(vals))
     @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
         S[ia, ib] = hopflink(a, b) # Normalized by total quantum dimension will change the data type of the S-matrix.
-    end
-
-    if I <: ProductSector
-        perm = sortperm(vec(collect(values(I))); by = Tuple) # using Tuple order to restore tensor product basis
-        S = S[perm, perm]
     end
 
     return S
@@ -741,7 +732,7 @@ function topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector
     end
 
     if isapprox(abs(c_float), 4; atol = tol)
-        return sign(c_float) * 4 // 1
+        return 4 // 1
     end
     return rationalize(c_float; tol = tol)
 end

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -705,9 +705,9 @@ end
 
 Check whether a sector type `I` is modular.
 """
-function ismodular(::Type{II}; tol = 1.0e-12) where {II <: Sector}
+function ismodular(::Type{II}; kwargs...) where {II <: Sector}
     s = Smatrix(II)
-    return isapprox(s' * s, sqdim(II) * I(size(s)[1]); atol = tol)
+    return isapprox(s' * s, sqdim(II) * I(size(s)[1]); kwargs...)
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -657,8 +657,6 @@ function topological_spin(a::Sector; tol = 1.0e-12)
     return rationalize(s; tol = tol)
 end
 
-anyonbasis(::Type{I}) where {I <: Sector} = vec(collect(values(I)))
-
 """
     Tmatrix(::Type{I}) where {I <: Sector}
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -713,6 +713,35 @@ function Smatrix(::Type{I}) where {I <: Sector}
 end
 
 """
+    ismodular(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+Check whether a sector `I` is modular.
+"""
+function ismodular(::Type{II}; tol = 1.0e-12) where {II <: Sector}
+    s = Smatrix(II)
+    return isapprox(s' * s, sqdim(II) * I(size(s)[1]); atol = tol)
+end
+
+"""
+    istransparent(a::I; tol = 1.0e-12) where {I <: Sector}
+Check whether the object `a` is in the Müger center of sector `I`.
+"""
+function istransparent(a::I; tol = 1.0e-12) where {I <: Sector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return all(b -> isapprox(hopflink(a, b), dim(a) * dim(b); atol = tol), values(I))
+end
+
+"""
+    mugercenter(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+Return a vector containing all simple objects in the Müger center of the sector `I`.
+"""
+function mugercenter(::Type{I}; tol = 1.0e-12) where {I <: Sector}
+    Base.IteratorSize(values(I)) isa Base.IsInfinite &&
+        throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
+    return collect(filter(a -> is_mugercentral(a; tol = tol), anyonbasis(I)))
+end
+
+"""
     topological_central_charge(::Type{I}; tol = 1.0e-12) where {I <: Sector}
 Return the topological central charge c of the modular sector type `I`, where c is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -647,6 +647,25 @@ twist(a::Sector) = twist_from_Rsymbol(a)
 twist_from_Rsymbol(a::Sector) = sum(dim(b) / dim(a) * tr(Rsymbol(a, a, b)) for b in a ⊗ a)
 
 """
+    spin_top(a::Sector; tol=1e-12)
+
+Return the topological spin of a sector `a`. Here we assume the range of the output as rational numbers within (-1 / 2, 1 / 2].
+"""
+function spin_top(a::Sector; tol = 1.0e-12)
+    s = angle(twist(a)) / (2π)
+    s = mod(s, 1)
+    if s > 0.5
+        s -= 1
+    end
+
+    if isapprox(abs(s), 0.5; atol = tol)
+        return sign(s) * (1 // 2)
+    end
+
+    return rationalize(s; tol = tol)
+end
+
+"""
     Tvector(::Type{I}) where {I <: Sector}
 
 Return the T-vector of the sector type `I`, which is a vector containing the twists of all sectors of type `I`.
@@ -713,13 +732,18 @@ end
 Return the topological central charge c_top of the modular sector type `I`, where `c_top` is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
-function c_top(::Type{I}) where {I <: Sector}
+function c_top(::Type{I}; tol = 1.0e-12) where {I <: Sector}
     ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
-    central_charge_top = imag(log(ξ) * 8 / 2pi)
-    if isapprox(central_charge_top, -4; atol = 1.0e-14)
-        return 4 // 1
+    ϕ = angle(ξ) * 8 / 2pi
+    c_float = mod(ϕ, 8)
+    if c_float > 4
+        c_float -= 8
     end
-    return rationalize(central_charge_top; tol = 1.0e-14)
+
+    if isapprox(abs(c_float), 4; atol = tol)
+        return sign(c_float) * 4 // 1
+    end
+    return rationalize(c_float; tol = tol)
 end
 
 # Operations between sectors of different types

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -710,10 +710,17 @@ end
 
 """
     topological_central_charge(::Type{I}) where {I <: Sector}
-Return the topological central charge of the modular sector type `I`, which is defined as the sum of the squares of the quantum dimensions of all sectors of type `I` weighted by their twists, divided by the total quantum dimension of `I`.
-Satisfying the relation `topological_central_charge(I) == exp(2πi c / 8)` where `c` is the chiral central charge mod 8 of the corresponding topological phase.
+Return the topological central charge c of the modular sector type `I`, where `c` is determined mod 8.
+We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
-topological_central_charge(::Type{I}) where {I <: Sector} = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
+function topological_central_charge(::Type{I}) where {I <: Sector}
+    ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
+    c_top = imag(log(ξ) * 8 / 2pi)
+    if isapprox(c_top, -4; atol = 1.0e-14)
+        return 4 // 1
+    end
+    return rationalize(c_top; tol = 1.0e-14)
+end
 
 # Operations between sectors of different types
 # ------------------------------------------------------------------------------

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -681,7 +681,12 @@ function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     vals = values(I)
-    return [hopflink(a, b) for a in vals, b in vals] / dim(I)
+    S = zeros(braidingscalartype(I), length(vals), length(vals))
+    d = dim(I)
+    @inbounds for (ib, b) in enumerate(vals), (ia, a) in enumerate(vals)
+        S[ia, ib] = hopflink(a, b) / d
+    end
+    return S
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -668,7 +668,7 @@ For ProductSector I ⊠ J, we have Tmatrix(I ⊠ J) == kron(Tmatrix(I), Tmatrix(
 function Tmatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return Diagonal(twist.(values(I)))
+    return Diagonal(vec(twist.(values(I))))
 end
 
 """
@@ -696,7 +696,12 @@ For ProductSector I ⊠ J, we have Smatrix(I ⊠ J) == kron(Smatrix(I), Smatrix(
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return [hopflink(a, b) for a in values(I), b in values(I)]
+    val = values(I)
+    S = zeros(braidingscalartype(I), length(val), length(val))
+    for (ia, a) in enumerate(val), (ib, b) in enumerate(val)
+        S[ia, ib] = hopflink(a, b)
+    end
+    return S
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -679,7 +679,8 @@ Return the S-matrix of the sector type `I`, which is a matrix containing the hop
 function Smatrix(::Type{I}) where {I <: Sector}
     Base.IteratorSize(values(I)) isa Base.IsInfinite &&
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
-    return reshape([hopflink(a, b) for a in values(I), b in values(I)], (length(values(I)), length(values(I)))) / dim(I)
+    vals = values(I)
+    return [hopflink(a, b) for a in vals, b in vals] / dim(I)
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -709,17 +709,17 @@ function Smatrix(::Type{I}) where {I <: Sector}
 end
 
 """
-    topological_central_charge(::Type{I}) where {I <: Sector}
-Return the topological central charge c of the modular sector type `I`, where `c` is determined mod 8.
+    c_top(::Type{I}) where {I <: Sector}
+Return the topological central charge c_top of the modular sector type `I`, where `c_top` is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
-function topological_central_charge(::Type{I}) where {I <: Sector}
+function c_top(::Type{I}) where {I <: Sector}
     ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / sqrt(sqDim(I))
-    c_top = imag(log(ξ) * 8 / 2pi)
-    if isapprox(c_top, -4; atol = 1.0e-14)
+    central_charge_top = imag(log(ξ) * 8 / 2pi)
+    if isapprox(central_charge_top, -4; atol = 1.0e-14)
         return 4 // 1
     end
-    return rationalize(c_top; tol = 1.0e-14)
+    return rationalize(central_charge_top; tol = 1.0e-14)
 end
 
 # Operations between sectors of different types

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,22 +192,36 @@ end
 end
 
 @testset "S matrix" begin
-    Smatrix(Z2Irrep) ≈ ones(2, 2) / 2
-    Smatrix(Z3Irrep) ≈ ones(3, 3) / 3
-    Smatrix(FermionParity) ≈ ones(2, 2) / 2
-    Smatrix(Z2Irrep ⊠ Z3Irrep) ≈ ones(6, 6) / 6
+    @test Smatrix(Z2Irrep) ≈ ones(2, 2) / sqrt(2)
+    @test Smatrix(Z3Irrep) ≈ ones(3, 3) / sqrt(3)
+    @test Smatrix(FermionParity) ≈ ones(2, 2) / sqrt(2)
+    @test Smatrix(Z2Irrep ⊠ Z3Irrep) ≈ ones(6, 6) / sqrt(6)
     φ = (1 + sqrt(5)) / 2
-    Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1] / sqrt(2 + φ)
-    Smatrix(IsingAnyon) ≈ [1 1 sqrt(2); 1 1 -sqrt(2); sqrt(2) -sqrt(2) 0] / 2
+    @test Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1] / sqrt(2 + φ)
+    @test Smatrix(IsingAnyon) ≈ [1 sqrt(2) 1; sqrt(2) 0 -sqrt(2); 1 -sqrt(2) 1] / 2
 end
 
-@testset "Modularity" begin
-    @test ismodular(Z2Irrep) == false
-    @test ismodular(Z3Irrep) == false
-    @test ismodular(FermionParity) == false
-    @test ismodular(Z2Irrep ⊠ Z3Irrep) == false
-    @test ismodular(FibonacciAnyon) == true
-    @test ismodular(IsingAnyon) == true
+@testset "Total quantum dimension" begin
+    @test dim(Z2Irrep) ≈ sqrt(2)
+    @test dim(Z3Irrep) ≈ sqrt(3)
+    @test dim(FermionParity) ≈ sqrt(2)
+    @test dim(Z2Irrep ⊠ Z3Irrep) ≈ sqrt(6)
+    φ = (1 + sqrt(5)) / 2
+    @test dim(FibonacciAnyon) ≈ sqrt(2 + φ)
+    @test dim(IsingAnyon) ≈ 2
+    @test dim(FibonacciAnyon ⊠ FibonacciAnyon) ≈ 2 + φ
+    @test dim(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 4
+end
+
+@testset "Multiplicative central charge" begin
+    @test ξ(IsingAnyon) ≈ cispi(1 / 8)
+    @test ξ(TimeReversed{IsingAnyon}) ≈ cispi(-1 / 8)
+    @test ξ(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ cispi(0)
+    @test ξ(FibonacciAnyon) ≈ cispi(- 7 / 5 / 2)
+    @test ξ(TimeReversed{FibonacciAnyon}) ≈ cispi(7 / 5 / 2)
+    @test ξ(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ cispi(0)
+    @test ξ(FibonacciAnyon ⊠ FibonacciAnyon) ≈ ξ(FibonacciAnyon)^2
+    @test ξ(FibonacciAnyon ⊠ IsingAnyon) ≈ ξ(FibonacciAnyon) * ξ(IsingAnyon)
 end
 
 include("multifusion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -270,10 +270,10 @@ end
 end
 
 @testset "Müger center" begin
-    @test mugercenter(Z2Irrep) == [Z2Irrep(0), Z2Irrep(1)]
-    @test mugercenter(FermionParity) == [FermionParity(0), FermionParity(1)]
-    @test mugercenter(IsingAnyon) == [IsingAnyon(:I)]
-    @test mugercenter(FibonacciAnyon) == [FibonacciAnyon(:I)]
+    @test transparent_anyons(Z2Irrep) == [Z2Irrep(0), Z2Irrep(1)]
+    @test transparent_anyons(FermionParity) == [FermionParity(0), FermionParity(1)]
+    @test transparent_anyons(IsingAnyon) == [IsingAnyon(:I)]
+    @test transparent_anyons(FibonacciAnyon) == [FibonacciAnyon(:I)]
 end
 
 @testset "Total quantum dimension" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,8 +201,6 @@ end
     @test topological_spin(TimeReversed{IsingAnyon}(:ψ)) == 1 // 2
     @test topological_spin(TimeReversed{IsingAnyon}(:σ)) == - 1 // 16
     @test topological_spin(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
-
-    @test topological_spin(IsingAnyon(:σ) ⊠ IsingAnyon(:σ)) == 1 // 8
 end
 
 @testset "T vector" begin
@@ -219,10 +217,8 @@ end
     @test Tvector(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ kron(Tvector(FibonacciAnyon), Tvector(TimeReversed{FibonacciAnyon}))
     @test Tvector(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tvector(FibonacciAnyon), Tvector(IsingAnyon))
     @test Tvector(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Tvector(IsingAnyon), Tvector(TimeReversed{IsingAnyon}))
-    @test Tvector(IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tvector(IsingAnyon), Tvector(FibonacciAnyon), Tvector(IsingAnyon))
 
     @test Tvector(A4Irrep) ≈ [1, 1, 1, 1]
-    @test Tvector(A4Irrep ⊠ IsingAnyon) ≈ kron(Tvector(A4Irrep), Tvector(IsingAnyon))
 end
 
 @testset "Hopf link" begin
@@ -233,8 +229,6 @@ end
     @test hopflink(IsingAnyon(:σ), IsingAnyon(:σ)) ≈ 0
     @test hopflink(IsingAnyon(:σ), IsingAnyon(:ψ)) ≈ -sqrt(2)
     @test hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) ≈ -1
-
-    @test hopflink(FibonacciAnyon(:τ) ⊠ IsingAnyon(:σ), FibonacciAnyon(:τ) ⊠ IsingAnyon(:ψ)) ≈ hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) * hopflink(IsingAnyon(:σ), IsingAnyon(:ψ))
 end
 @testset "S matrix" begin
     @test Smatrix(Z2Irrep) ≈ ones(2, 2)
@@ -257,7 +251,6 @@ end
     @test Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Smatrix(IsingAnyon), Smatrix(TimeReversed{IsingAnyon}))
     @test Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon) ≈ kron(Smatrix(TimeReversed{FibonacciAnyon}), Smatrix(IsingAnyon))
     @test Smatrix(IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(IsingAnyon), Smatrix(IsingAnyon), Smatrix(IsingAnyon))
-    @test Smatrix(IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(IsingAnyon), Smatrix(FibonacciAnyon), Smatrix(IsingAnyon))
 end
 
 @testset "Total quantum dimension" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using TestExtras
 using TensorKitSectors
+using LinearAlgebra: Diagonal
 
 include("newsectors.jl")
 using .NewSectors
@@ -203,22 +204,25 @@ end
     @test topological_spin(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
 end
 
-@testset "T vector" begin
-    @test Tvector(Z2Irrep) ≈ [1, 1]
-    @test Tvector(Z3Irrep) ≈ [1, 1, 1]
-    @test Tvector(FermionParity) ≈ [1, -1]
-    @test Tvector(Z2Irrep ⊠ Z3Irrep) ≈ ones(6)
-    @test Tvector(FibonacciAnyon) ≈ [1, cispi(-4 / 5)]
-    @test Tvector(IsingAnyon) ≈ [1, cispi(1 / 8), -1]
-    @test Tvector(TimeReversed{IsingAnyon}) ≈ [1, cispi(-1 / 8), -1]
-    @test Tvector(TimeReversed{FibonacciAnyon}) ≈ [1, cispi(4 / 5)]
+@testset "T matrix" begin
+    @test Tmatrix(Z2Irrep) ≈ Diagonal([1, 1])
+    @test Tmatrix(Z3Irrep) ≈ Diagonal([1, 1, 1])
+    @test Tmatrix(FermionParity) ≈ Diagonal([1, -1])
+    @test Tmatrix(Z2Irrep ⊠ Z3Irrep) ≈ Diagonal(ones(6))
+    @test Tmatrix(FibonacciAnyon) ≈ Diagonal([1, cispi(-4 / 5)])
+    @test Tmatrix(IsingAnyon) ≈ Diagonal([1, cispi(1 / 8), -1])
+    @test Tmatrix(TimeReversed{IsingAnyon}) ≈ Diagonal([1, cispi(-1 / 8), -1])
+    @test Tmatrix(TimeReversed{FibonacciAnyon}) ≈ Diagonal([1, cispi(4 / 5)])
 
-    @test Tvector(FibonacciAnyon ⊠ FibonacciAnyon) ≈ kron(Tvector(FibonacciAnyon), Tvector(FibonacciAnyon))
-    @test Tvector(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ kron(Tvector(FibonacciAnyon), Tvector(TimeReversed{FibonacciAnyon}))
-    @test Tvector(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tvector(FibonacciAnyon), Tvector(IsingAnyon))
-    @test Tvector(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Tvector(IsingAnyon), Tvector(TimeReversed{IsingAnyon}))
+    @test Tmatrix(FibonacciAnyon ⊠ FibonacciAnyon) ≈ kron(Tmatrix(FibonacciAnyon), Tmatrix(FibonacciAnyon))
+    @test Tmatrix(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ kron(Tmatrix(FibonacciAnyon), Tmatrix(TimeReversed{FibonacciAnyon}))
+    @test Tmatrix(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tmatrix(FibonacciAnyon), Tmatrix(IsingAnyon))
+    @test Tmatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Tmatrix(IsingAnyon), Tmatrix(TimeReversed{IsingAnyon}))
 
-    @test Tvector(A4Irrep) ≈ [1, 1, 1, 1]
+    @test Tmatrix(A4Irrep) ≈ Diagonal([1, 1, 1, 1])
+
+    @test Diagonal(twist.(anyonbasis(IsingAnyon ⊠ FibonacciAnyon ⊠ TimeReversed{IsingAnyon}))) ≈ Tmatrix(IsingAnyon ⊠ FibonacciAnyon ⊠ TimeReversed{IsingAnyon})
+    @test Diagonal(twist.(anyonbasis(FibonacciAnyon ⊠ IsingAnyon))) ≈ Tmatrix(FibonacciAnyon ⊠ IsingAnyon)
 end
 
 @testset "Hopf link" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,7 +225,7 @@ end
     @test Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1] / sqrt(2 + φ)
     @test Smatrix(IsingAnyon) ≈ [1 sqrt(2) 1; sqrt(2) 0 -sqrt(2); 1 -sqrt(2) 1] / 2
 
-    @info "S matrix is symmetric"
+    # S matrix is symmetric
     @test transpose(Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)
     @test transpose(Smatrix(FibonacciAnyon ⊠ IsingAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ IsingAnyon)
     @test transpose(Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})) ≈ Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -233,6 +233,7 @@ end
     @test hopflink(IsingAnyon(:σ), IsingAnyon(:σ)) ≈ 0
     @test hopflink(IsingAnyon(:σ), IsingAnyon(:ψ)) ≈ -sqrt(2)
     @test hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) ≈ -1
+    @test hopflink(IsingAnyon(:ψ) ⊠ FibonacciAnyon(:τ), IsingAnyon(:σ) ⊠ FibonacciAnyon(:τ)) ≈ hopflink(IsingAnyon(:ψ), IsingAnyon(:σ)) * hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ))
 end
 @testset "S matrix" begin
     @test Smatrix(Z2Irrep) ≈ ones(2, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,6 +238,7 @@ end
     @test Smatrix(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(FibonacciAnyon), Smatrix(IsingAnyon))
     @test Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Smatrix(IsingAnyon), Smatrix(TimeReversed{IsingAnyon}))
     @test Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon) ≈ kron(Smatrix(TimeReversed{FibonacciAnyon}), Smatrix(IsingAnyon))
+    @test Smatrix(IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(IsingAnyon), Smatrix(IsingAnyon), Smatrix(IsingAnyon))
 end
 
 @testset "Total quantum dimension" begin
@@ -253,14 +254,15 @@ end
 end
 
 @testset "Topological central charge" begin
-    @test topological_central_charge(IsingAnyon) ≈ cispi(1 / 8)
-    @test topological_central_charge(TimeReversed{IsingAnyon}) ≈ cispi(-1 / 8)
-    @test topological_central_charge(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 1
-    @test topological_central_charge(FibonacciAnyon) ≈ cispi(- 7 / 5 / 2)
-    @test topological_central_charge(TimeReversed{FibonacciAnyon}) ≈ cispi(7 / 5 / 2)
-    @test topological_central_charge(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ 1
-    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon) ≈ topological_central_charge(FibonacciAnyon)^2
-    @test topological_central_charge(FibonacciAnyon ⊠ IsingAnyon) ≈ topological_central_charge(FibonacciAnyon) * topological_central_charge(IsingAnyon)
+    @test topological_central_charge(IsingAnyon) == 1 // 2
+    @test topological_central_charge(TimeReversed{IsingAnyon}) == - 1 // 2
+    @test topological_central_charge(IsingAnyon ⊠ TimeReversed{IsingAnyon}) == 0 // 1
+    @test topological_central_charge(FibonacciAnyon) == - 14 // 5
+    @test topological_central_charge(TimeReversed{FibonacciAnyon}) == 14 // 5
+    @test topological_central_charge(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) == 0 // 1
+    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon ⊠ FibonacciAnyon) == mod(- 3 * 14 // 5 + 4, 8) - 4
+    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon) == mod(2 * topological_central_charge(FibonacciAnyon) + 4, 8) - 4
+    @test topological_central_charge(FibonacciAnyon ⊠ IsingAnyon) == mod(topological_central_charge(FibonacciAnyon) + topological_central_charge(IsingAnyon) + 4, 8) - 4
 end
 
 include("multifusion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,8 +250,6 @@ end
         l = length(vals)
         Smat = Smatrix(sector)
         Tmat = Tmatrix(sector)
-        @test Smat ≈ reshape([hopflink(a, b) for a in vals, b in vals], (l, l))
-        @test Tmat ≈ Diagonal(vec(twist.(vals)))
         @test transpose(Smat) ≈ Smat
         @test Smat' * Smat ≈ identity_matrix(l) * sqdim(sector)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,6 +240,7 @@ end
     @test Tmatrix(TimeReversed{FibonacciAnyon}) ≈ Diagonal([1, cispi(4 / 5)])
 
     umtc_list = [
+        IsingAnyon, FibonacciAnyon, TimeReversed{IsingAnyon}, TimeReversed{FibonacciAnyon},
         FibonacciAnyon ⊠ FibonacciAnyon, FibonacciAnyon ⊠ IsingAnyon, IsingAnyon ⊠ TimeReversed{IsingAnyon},
         TimeReversed{FibonacciAnyon} ⊠ IsingAnyon, IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon,
         IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon ⊠ TimeReversed{IsingAnyon} ⊠ TimeReversed{FibonacciAnyon},
@@ -248,9 +249,13 @@ end
         vals = values(sector)
         l = length(vals)
         Smat = Smatrix(sector)
+        smat = Smat / dim(sector)
         Tmat = Tmatrix(sector)
-        @test transpose(Smat) ≈ Smat
-        @test Smat' * Smat ≈ identity_matrix(l) * dim(sector)^2
+        c = topological_central_charge(sector)
+        @test transpose(Smat) ≈ Smat # S matrix is symmetric
+        @test (smat * Tmat)^3 ≈ cispi(2 * c / 8) * smat^2 # projective rep of modular group
+        @test smat^4 ≈ identity_matrix(l)
+        @test smat' * smat ≈ identity_matrix(l) # S matrix is unitary
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,15 +258,15 @@ end
 end
 
 @testset "Total quantum dimension" begin
-    @test sqDim(Z2Irrep) ≈ 2
-    @test sqDim(Z3Irrep) ≈ 3
-    @test sqDim(FermionParity) ≈ 2
-    @test sqDim(Z2Irrep ⊠ Z3Irrep) ≈ 6
+    @test sqdim(Z2Irrep) ≈ 2
+    @test sqdim(Z3Irrep) ≈ 3
+    @test sqdim(FermionParity) ≈ 2
+    @test sqdim(Z2Irrep ⊠ Z3Irrep) ≈ 6
     φ = (1 + sqrt(5)) / 2
-    @test sqDim(FibonacciAnyon) ≈ 2 + φ
-    @test sqDim(IsingAnyon) ≈ 4
-    @test sqDim(FibonacciAnyon ⊠ FibonacciAnyon) ≈ (2 + φ)^2
-    @test sqDim(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 16
+    @test sqdim(FibonacciAnyon) ≈ 2 + φ
+    @test sqdim(IsingAnyon) ≈ 4
+    @test sqdim(FibonacciAnyon ⊠ FibonacciAnyon) ≈ (2 + φ)^2
+    @test sqdim(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 16
 end
 
 @testset "Topological central charge" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,6 +191,31 @@ end
     end
 end
 
+@testset "T vector" begin
+    @test Tvector(Z2Irrep) ≈ [1, 1]
+    @test Tvector(Z3Irrep) ≈ [1, 1, 1]
+    @test Tvector(FermionParity) ≈ [1, -1]
+    @test Tvector(Z2Irrep ⊠ Z3Irrep) ≈ ones(6)
+    @test Tvector(FibonacciAnyon) ≈ [1, cispi(-4 / 5)]
+    @test Tvector(IsingAnyon) ≈ [1, cispi(1 / 8), -1]
+    @test Tvector(TimeReversed{IsingAnyon}) ≈ [1, cispi(-1 / 8), -1]
+    @test Tvector(TimeReversed{FibonacciAnyon}) ≈ [1, cispi(4 / 5)]
+
+    @test Tvector(FibonacciAnyon ⊠ FibonacciAnyon) ≈ [1, cispi(-4 / 5), cispi(-4 / 5), cispi(-8 / 5)]
+    @test Tvector(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ [1, cispi(4 / 5), cispi(-4 / 5), 1]
+    @test Tvector(FibonacciAnyon ⊠ IsingAnyon) ≈ [1, cispi(1 / 8), cispi(-4 / 5), -1, cispi(1 / 8 - 4 / 5), - cispi(-4 / 5)]
+    @test Tvector(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ [1, cispi(- 1 / 8), cispi(1 / 8), -1, 1, -1, -cispi(1 / 8), -cispi(-1 / 8), 1]
+end
+
+@testset "Hopf link" begin
+    @test hopflink(Z2Irrep(1), Z2Irrep(1)) ≈ 1
+    @test hopflink(Z3Irrep(1), Z3Irrep(2)) ≈ 1
+    @test hopflink(FermionParity(1), FermionParity(1)) ≈ 1
+    @test hopflink(IsingAnyon(:ψ), IsingAnyon(:ψ)) ≈ 1
+    @test hopflink(IsingAnyon(:σ), IsingAnyon(:σ)) ≈ 0
+    @test hopflink(IsingAnyon(:σ), IsingAnyon(:ψ)) ≈ -sqrt(2)
+    @test hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) ≈ -1
+end
 @testset "S matrix" begin
     @test Smatrix(Z2Irrep) ≈ ones(2, 2) / sqrt(2)
     @test Smatrix(Z3Irrep) ≈ ones(3, 3) / sqrt(3)
@@ -199,6 +224,12 @@ end
     φ = (1 + sqrt(5)) / 2
     @test Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1] / sqrt(2 + φ)
     @test Smatrix(IsingAnyon) ≈ [1 sqrt(2) 1; sqrt(2) 0 -sqrt(2); 1 -sqrt(2) 1] / 2
+
+    @info "S matrix is symmetric"
+    @test transpose(Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)
+    @test transpose(Smatrix(FibonacciAnyon ⊠ IsingAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ IsingAnyon)
+    @test transpose(Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})) ≈ Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})
+    @test transpose(Smatrix(FibonacciAnyon ⊠ IsingAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ IsingAnyon)
 end
 
 @testset "Total quantum dimension" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,6 +202,10 @@ end
     @test topological_spin(TimeReversed{IsingAnyon}(:ψ)) == 1 // 2
     @test topological_spin(TimeReversed{IsingAnyon}(:σ)) == - 1 // 16
     @test topological_spin(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
+    @test topological_spin.(anyonbasis(FibonacciAnyon ⊠ FibonacciAnyon)) == [0 // 1, -2 // 5, -2 // 5, 1 // 5]
+    @test topological_spin.(anyonbasis(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon})) == [0 // 1, 2 // 5, -2 // 5, 0 // 1]
+    @test topological_spin.(anyonbasis(IsingAnyon ⊠ TimeReversed{IsingAnyon})) == [0 // 1, -1 // 16, 1 // 2, 1 // 16, 0 // 1, - 7 // 16, 1 // 2, 7 // 16, 0 // 1]
+    @test topological_spin.(anyonbasis(IsingAnyon ⊠ IsingAnyon)) == [0 // 1, 1 // 16, 1 // 2, 1 // 16, 1 // 8, - 7 // 16, 1 // 2, -7 // 16, 0 // 1]
 end
 
 @testset "T matrix" begin
@@ -275,6 +279,9 @@ end
     @test transparent_anyons(FermionParity) == [FermionParity(0), FermionParity(1)]
     @test transparent_anyons(IsingAnyon) == [IsingAnyon(:I)]
     @test transparent_anyons(FibonacciAnyon) == [FibonacciAnyon(:I)]
+    @test transparent_anyons(FibonacciAnyon ⊠ IsingAnyon) == [FibonacciAnyon(:I) ⊠ IsingAnyon(:I)]
+    @test transparent_anyons(Z2Irrep ⊠ FibonacciAnyon) == [Z2Irrep(0) ⊠ FibonacciAnyon(:I), Z2Irrep(1) ⊠ FibonacciAnyon(:I)]
+    @test transparent_anyons(FibonacciAnyon ⊠ Z3Irrep) == [FibonacciAnyon(:I) ⊠ Z3Irrep(0), FibonacciAnyon(:I) ⊠ Z3Irrep(1), FibonacciAnyon(:I) ⊠ Z3Irrep(2)]
 end
 
 @testset "Total quantum dimension" begin
@@ -299,6 +306,7 @@ end
     @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon ⊠ FibonacciAnyon) == mod(- 3 * 14 // 5 + 4, 8) - 4
     @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon) == mod(2 * topological_central_charge(FibonacciAnyon) + 4, 8) - 4
     @test topological_central_charge(FibonacciAnyon ⊠ IsingAnyon) == mod(topological_central_charge(FibonacciAnyon) + topological_central_charge(IsingAnyon) + 4, 8) - 4
+    @test topological_central_charge(⊠(fill(TimeReversed{IsingAnyon}, 8)...)) == 4 // 1
 end
 
 include("multifusion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,10 +203,10 @@ end
     @test topological_spin(TimeReversed{IsingAnyon}(:ψ)) == 1 // 2
     @test topological_spin(TimeReversed{IsingAnyon}(:σ)) == - 1 // 16
     @test topological_spin(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
-    @test topological_spin.(anyonbasis(FibonacciAnyon ⊠ FibonacciAnyon)) == [0 // 1, -2 // 5, -2 // 5, 1 // 5]
-    @test topological_spin.(anyonbasis(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon})) == [0 // 1, 2 // 5, -2 // 5, 0 // 1]
-    @test topological_spin.(anyonbasis(IsingAnyon ⊠ TimeReversed{IsingAnyon})) == [0 // 1, -1 // 16, 1 // 16, 1 // 2, 0, 1 // 2, -7 // 16, 7 // 16, 0 // 1]
-    @test topological_spin.(anyonbasis(IsingAnyon ⊠ IsingAnyon)) == [0 // 1, 1 // 16, 1 // 16, 1 // 2, 1 // 8, 1 // 2, -7 // 16, -7 // 16, 0 // 1]
+    @test vec(topological_spin.(values(FibonacciAnyon ⊠ FibonacciAnyon))) == [0 // 1, -2 // 5, -2 // 5, 1 // 5]
+    @test vec(topological_spin.(values(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}))) == [0 // 1, 2 // 5, -2 // 5, 0 // 1]
+    @test vec(topological_spin.(values(IsingAnyon ⊠ TimeReversed{IsingAnyon}))) == [0 // 1, -1 // 16, 1 // 16, 1 // 2, 0, 1 // 2, -7 // 16, 7 // 16, 0 // 1]
+    @test vec(topological_spin.(values(IsingAnyon ⊠ IsingAnyon))) == [0 // 1, 1 // 16, 1 // 16, 1 // 2, 1 // 8, 1 // 2, -7 // 16, -7 // 16, 0 // 1]
 end
 
 @testset "Hopf link" begin
@@ -245,13 +245,12 @@ end
         IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon ⊠ TimeReversed{IsingAnyon} ⊠ TimeReversed{FibonacciAnyon},
     ]
     for sector in umtc_list
-        @test anyonbasis(sector) == vec(collect(values(sector)))
         vals = values(sector)
         l = length(vals)
         Smat = Smatrix(sector)
         Tmat = Tmatrix(sector)
         @test transpose(Smat) ≈ Smat
-        @test Smat' * Smat ≈ identity_matrix(l) * sqdim(sector)
+        @test Smat' * Smat ≈ identity_matrix(l) * dim(sector)^2
     end
 end
 
@@ -267,26 +266,16 @@ end
     @test ismodular(IsingAnyon ⊠ TimeReversed{IsingAnyon})
 end
 
-@testset "Müger center" begin
-    @test transparent_anyons(Z2Irrep) == [Z2Irrep(0), Z2Irrep(1)]
-    @test transparent_anyons(FermionParity) == [FermionParity(0), FermionParity(1)]
-    @test transparent_anyons(IsingAnyon) == [IsingAnyon(:I)]
-    @test transparent_anyons(FibonacciAnyon) == [FibonacciAnyon(:I)]
-    @test transparent_anyons(FibonacciAnyon ⊠ IsingAnyon) == [FibonacciAnyon(:I) ⊠ IsingAnyon(:I)]
-    @test transparent_anyons(Z2Irrep ⊠ FibonacciAnyon) == [Z2Irrep(0) ⊠ FibonacciAnyon(:I), Z2Irrep(1) ⊠ FibonacciAnyon(:I)]
-    @test transparent_anyons(FibonacciAnyon ⊠ Z3Irrep) == [FibonacciAnyon(:I) ⊠ Z3Irrep(0), FibonacciAnyon(:I) ⊠ Z3Irrep(1), FibonacciAnyon(:I) ⊠ Z3Irrep(2)]
-end
-
 @testset "Total quantum dimension" begin
-    @test sqdim(Z2Irrep) ≈ 2
-    @test sqdim(Z3Irrep) ≈ 3
-    @test sqdim(FermionParity) ≈ 2
-    @test sqdim(Z2Irrep ⊠ Z3Irrep) ≈ 6
+    @test dim(Z2Irrep)^2 ≈ 2
+    @test dim(Z3Irrep)^2 ≈ 3
+    @test dim(FermionParity)^2 ≈ 2
+    @test dim(Z2Irrep ⊠ Z3Irrep)^2 ≈ 6
     φ = (1 + sqrt(5)) / 2
-    @test sqdim(FibonacciAnyon) ≈ 2 + φ
-    @test sqdim(IsingAnyon) ≈ 4
-    @test sqdim(FibonacciAnyon ⊠ FibonacciAnyon) ≈ (2 + φ)^2
-    @test sqdim(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 16
+    @test dim(FibonacciAnyon)^2 ≈ 2 + φ
+    @test dim(IsingAnyon)^2 ≈ 4
+    @test dim(FibonacciAnyon ⊠ FibonacciAnyon)^2 ≈ (2 + φ)^2
+    @test dim(IsingAnyon ⊠ TimeReversed{IsingAnyon})^2 ≈ 16
 end
 
 @testset "Topological central charge" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,15 +192,15 @@ end
 end
 
 @testset "Topological spin" begin
-    @test spin_top(IsingAnyon(:I)) == 0 // 1
-    @test spin_top(IsingAnyon(:σ)) == 1 // 16
-    @test spin_top(IsingAnyon(:ψ)) == 1 // 2
-    @test spin_top(FibonacciAnyon(:τ)) == - 2 // 5
-    @test spin_top(FibonacciAnyon(:I)) == 0 // 1
-    @test spin_top(Z2Irrep(1)) == 0 // 1
-    @test spin_top(TimeReversed{IsingAnyon}(:ψ)) == 1 // 2
-    @test spin_top(TimeReversed{IsingAnyon}(:σ)) == - 1 // 16
-    @test spin_top(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
+    @test topological_spin(IsingAnyon(:I)) == 0 // 1
+    @test topological_spin(IsingAnyon(:σ)) == 1 // 16
+    @test topological_spin(IsingAnyon(:ψ)) == 1 // 2
+    @test topological_spin(FibonacciAnyon(:τ)) == - 2 // 5
+    @test topological_spin(FibonacciAnyon(:I)) == 0 // 1
+    @test topological_spin(Z2Irrep(1)) == 0 // 1
+    @test topological_spin(TimeReversed{IsingAnyon}(:ψ)) == 1 // 2
+    @test topological_spin(TimeReversed{IsingAnyon}(:σ)) == - 1 // 16
+    @test topological_spin(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
 end
 
 @testset "T vector" begin
@@ -266,15 +266,15 @@ end
 end
 
 @testset "Topological central charge" begin
-    @test c_top(IsingAnyon) == 1 // 2
-    @test c_top(TimeReversed{IsingAnyon}) == - 1 // 2
-    @test c_top(IsingAnyon ⊠ TimeReversed{IsingAnyon}) == 0 // 1
-    @test c_top(FibonacciAnyon) == - 14 // 5
-    @test c_top(TimeReversed{FibonacciAnyon}) == 14 // 5
-    @test c_top(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) == 0 // 1
-    @test c_top(FibonacciAnyon ⊠ FibonacciAnyon ⊠ FibonacciAnyon) == mod(- 3 * 14 // 5 + 4, 8) - 4
-    @test c_top(FibonacciAnyon ⊠ FibonacciAnyon) == mod(2 * c_top(FibonacciAnyon) + 4, 8) - 4
-    @test c_top(FibonacciAnyon ⊠ IsingAnyon) == mod(c_top(FibonacciAnyon) + c_top(IsingAnyon) + 4, 8) - 4
+    @test topological_central_charge(IsingAnyon) == 1 // 2
+    @test topological_central_charge(TimeReversed{IsingAnyon}) == - 1 // 2
+    @test topological_central_charge(IsingAnyon ⊠ TimeReversed{IsingAnyon}) == 0 // 1
+    @test topological_central_charge(FibonacciAnyon) == - 14 // 5
+    @test topological_central_charge(TimeReversed{FibonacciAnyon}) == 14 // 5
+    @test topological_central_charge(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) == 0 // 1
+    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon ⊠ FibonacciAnyon) == mod(- 3 * 14 // 5 + 4, 8) - 4
+    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon) == mod(2 * topological_central_charge(FibonacciAnyon) + 4, 8) - 4
+    @test topological_central_charge(FibonacciAnyon ⊠ IsingAnyon) == mod(topological_central_charge(FibonacciAnyon) + topological_central_charge(IsingAnyon) + 4, 8) - 4
 end
 
 include("multifusion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -254,15 +254,15 @@ end
 end
 
 @testset "Topological central charge" begin
-    @test topological_central_charge(IsingAnyon) == 1 // 2
-    @test topological_central_charge(TimeReversed{IsingAnyon}) == - 1 // 2
-    @test topological_central_charge(IsingAnyon ⊠ TimeReversed{IsingAnyon}) == 0 // 1
-    @test topological_central_charge(FibonacciAnyon) == - 14 // 5
-    @test topological_central_charge(TimeReversed{FibonacciAnyon}) == 14 // 5
-    @test topological_central_charge(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) == 0 // 1
-    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon ⊠ FibonacciAnyon) == mod(- 3 * 14 // 5 + 4, 8) - 4
-    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon) == mod(2 * topological_central_charge(FibonacciAnyon) + 4, 8) - 4
-    @test topological_central_charge(FibonacciAnyon ⊠ IsingAnyon) == mod(topological_central_charge(FibonacciAnyon) + topological_central_charge(IsingAnyon) + 4, 8) - 4
+    @test c_top(IsingAnyon) == 1 // 2
+    @test c_top(TimeReversed{IsingAnyon}) == - 1 // 2
+    @test c_top(IsingAnyon ⊠ TimeReversed{IsingAnyon}) == 0 // 1
+    @test c_top(FibonacciAnyon) == - 14 // 5
+    @test c_top(TimeReversed{FibonacciAnyon}) == 14 // 5
+    @test c_top(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) == 0 // 1
+    @test c_top(FibonacciAnyon ⊠ FibonacciAnyon ⊠ FibonacciAnyon) == mod(- 3 * 14 // 5 + 4, 8) - 4
+    @test c_top(FibonacciAnyon ⊠ FibonacciAnyon) == mod(2 * c_top(FibonacciAnyon) + 4, 8) - 4
+    @test c_top(FibonacciAnyon ⊠ IsingAnyon) == mod(c_top(FibonacciAnyon) + c_top(IsingAnyon) + 4, 8) - 4
 end
 
 include("multifusion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,6 +191,18 @@ end
     end
 end
 
+@testset "Topological spin" begin
+    @test spin_top(IsingAnyon(:I)) == 0 // 1
+    @test spin_top(IsingAnyon(:σ)) == 1 // 16
+    @test spin_top(IsingAnyon(:ψ)) == 1 // 2
+    @test spin_top(FibonacciAnyon(:τ)) == - 2 // 5
+    @test spin_top(FibonacciAnyon(:I)) == 0 // 1
+    @test spin_top(Z2Irrep(1)) == 0 // 1
+    @test spin_top(TimeReversed{IsingAnyon}(:ψ)) == 1 // 2
+    @test spin_top(TimeReversed{IsingAnyon}(:σ)) == - 1 // 16
+    @test spin_top(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
+end
+
 @testset "T vector" begin
     @test Tvector(Z2Irrep) ≈ [1, 1]
     @test Tvector(Z3Irrep) ≈ [1, 1, 1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,6 +191,25 @@ end
     end
 end
 
+@testset "S matrix" begin
+    Smatrix(Z2Irrep) ≈ ones(2, 2) / 2
+    Smatrix(Z3Irrep) ≈ ones(3, 3) / 3
+    Smatrix(FermionParity) ≈ ones(2, 2) / 2
+    Smatrix(Z2Irrep ⊠ Z3Irrep) ≈ ones(6, 6) / 6
+    φ = (1 + sqrt(5)) / 2
+    Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1] / sqrt(2 + φ)
+    Smatrix(IsingAnyon) ≈ [1 1 sqrt(2); 1 1 -sqrt(2); sqrt(2) -sqrt(2) 0] / 2
+end
+
+@testset "Modularity" begin
+    @test ismodular(Z2Irrep) == false
+    @test ismodular(Z3Irrep) == false
+    @test ismodular(FermionParity) == false
+    @test ismodular(Z2Irrep ⊠ Z3Irrep) == false
+    @test ismodular(FibonacciAnyon) == true
+    @test ismodular(IsingAnyon) == true
+end
+
 include("multifusion.jl")
 
 @testset "Aqua" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,25 @@ end
     @test Smatrix(IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(IsingAnyon), Smatrix(IsingAnyon), Smatrix(IsingAnyon))
 end
 
+@testset "Ismodular" begin
+    @test !ismodular(Z2Irrep)
+    @test !ismodular(Z3Irrep)
+    @test !ismodular(FermionParity)
+    @test !ismodular(A4Irrep)
+    @test !ismodular(IsingAnyon ⊠ Z2Irrep)
+    @test ismodular(IsingAnyon)
+    @test ismodular(FibonacciAnyon)
+    @test ismodular(TimeReversed{IsingAnyon})
+    @test ismodular(IsingAnyon ⊠ TimeReversed{IsingAnyon})
+end
+
+@testset "Müger center" begin
+    @test mugercenter(Z2Irrep) == [Z2Irrep(0), Z2Irrep(1)]
+    @test mugercenter(FermionParity) == [FermionParity(0), FermionParity(1)]
+    @test mugercenter(IsingAnyon) == [IsingAnyon(:I)]
+    @test mugercenter(FibonacciAnyon) == [FibonacciAnyon(:I)]
+end
+
 @testset "Total quantum dimension" begin
     @test sqdim(Z2Irrep) ≈ 2
     @test sqdim(Z3Irrep) ≈ 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,7 +250,7 @@ end
     @test ξ(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 1
     @test ξ(FibonacciAnyon) ≈ cispi(- 7 / 5 / 2)
     @test ξ(TimeReversed{FibonacciAnyon}) ≈ cispi(7 / 5 / 2)
-    @test ξ(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ cispi(0)
+    @test ξ(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ 1
     @test ξ(FibonacciAnyon ⊠ FibonacciAnyon) ≈ ξ(FibonacciAnyon)^2
     @test ξ(FibonacciAnyon ⊠ IsingAnyon) ≈ ξ(FibonacciAnyon) * ξ(IsingAnyon)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,6 +201,8 @@ end
     @test topological_spin(TimeReversed{IsingAnyon}(:ψ)) == 1 // 2
     @test topological_spin(TimeReversed{IsingAnyon}(:σ)) == - 1 // 16
     @test topological_spin(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
+
+    @test topological_spin(IsingAnyon(:σ) ⊠ IsingAnyon(:σ)) == 1 // 8
 end
 
 @testset "T vector" begin
@@ -217,8 +219,10 @@ end
     @test Tvector(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ kron(Tvector(FibonacciAnyon), Tvector(TimeReversed{FibonacciAnyon}))
     @test Tvector(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tvector(FibonacciAnyon), Tvector(IsingAnyon))
     @test Tvector(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Tvector(IsingAnyon), Tvector(TimeReversed{IsingAnyon}))
+    @test Tvector(IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tvector(IsingAnyon), Tvector(FibonacciAnyon), Tvector(IsingAnyon))
 
     @test Tvector(A4Irrep) ≈ [1, 1, 1, 1]
+    @test Tvector(A4Irrep ⊠ IsingAnyon) ≈ kron(Tvector(A4Irrep), Tvector(IsingAnyon))
 end
 
 @testset "Hopf link" begin
@@ -229,6 +233,8 @@ end
     @test hopflink(IsingAnyon(:σ), IsingAnyon(:σ)) ≈ 0
     @test hopflink(IsingAnyon(:σ), IsingAnyon(:ψ)) ≈ -sqrt(2)
     @test hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) ≈ -1
+
+    @test hopflink(FibonacciAnyon(:τ) ⊠ IsingAnyon(:σ), FibonacciAnyon(:τ) ⊠ IsingAnyon(:ψ)) ≈ hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) * hopflink(IsingAnyon(:σ), IsingAnyon(:ψ))
 end
 @testset "S matrix" begin
     @test Smatrix(Z2Irrep) ≈ ones(2, 2)
@@ -251,6 +257,7 @@ end
     @test Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Smatrix(IsingAnyon), Smatrix(TimeReversed{IsingAnyon}))
     @test Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon) ≈ kron(Smatrix(TimeReversed{FibonacciAnyon}), Smatrix(IsingAnyon))
     @test Smatrix(IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(IsingAnyon), Smatrix(IsingAnyon), Smatrix(IsingAnyon))
+    @test Smatrix(IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(IsingAnyon), Smatrix(FibonacciAnyon), Smatrix(IsingAnyon))
 end
 
 @testset "Total quantum dimension" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,7 +247,7 @@ end
 @testset "Multiplicative central charge" begin
     @test ξ(IsingAnyon) ≈ cispi(1 / 8)
     @test ξ(TimeReversed{IsingAnyon}) ≈ cispi(-1 / 8)
-    @test ξ(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ cispi(0)
+    @test ξ(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 1
     @test ξ(FibonacciAnyon) ≈ cispi(- 7 / 5 / 2)
     @test ξ(TimeReversed{FibonacciAnyon}) ≈ cispi(7 / 5 / 2)
     @test ξ(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ cispi(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,10 +201,10 @@ end
     @test Tvector(TimeReversed{IsingAnyon}) ≈ [1, cispi(-1 / 8), -1]
     @test Tvector(TimeReversed{FibonacciAnyon}) ≈ [1, cispi(4 / 5)]
 
-    @test Tvector(FibonacciAnyon ⊠ FibonacciAnyon) ≈ [1, cispi(-4 / 5), cispi(-4 / 5), cispi(-8 / 5)]
-    @test Tvector(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ [1, cispi(4 / 5), cispi(-4 / 5), 1]
-    @test Tvector(FibonacciAnyon ⊠ IsingAnyon) ≈ [1, cispi(1 / 8), cispi(-4 / 5), -1, cispi(1 / 8 - 4 / 5), - cispi(-4 / 5)]
-    @test Tvector(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ [1, cispi(- 1 / 8), cispi(1 / 8), -1, 1, -1, -cispi(1 / 8), -cispi(-1 / 8), 1]
+    @test Tvector(FibonacciAnyon ⊠ FibonacciAnyon) ≈ kron(Tvector(FibonacciAnyon), Tvector(FibonacciAnyon))
+    @test Tvector(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ kron(Tvector(FibonacciAnyon), Tvector(TimeReversed{FibonacciAnyon}))
+    @test Tvector(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tvector(FibonacciAnyon), Tvector(IsingAnyon))
+    @test Tvector(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Tvector(IsingAnyon), Tvector(TimeReversed{IsingAnyon}))
 
     @test Tvector(A4Irrep) ≈ [1, 1, 1, 1]
 end
@@ -219,42 +219,48 @@ end
     @test hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) ≈ -1
 end
 @testset "S matrix" begin
-    @test Smatrix(Z2Irrep) ≈ ones(2, 2) / sqrt(2)
-    @test Smatrix(Z3Irrep) ≈ ones(3, 3) / sqrt(3)
-    @test Smatrix(FermionParity) ≈ ones(2, 2) / sqrt(2)
-    @test Smatrix(Z2Irrep ⊠ Z3Irrep) ≈ ones(6, 6) / sqrt(6)
+    @test Smatrix(Z2Irrep) ≈ ones(2, 2)
+    @test Smatrix(Z3Irrep) ≈ ones(3, 3)
+    @test Smatrix(FermionParity) ≈ ones(2, 2)
+    @test Smatrix(Z2Irrep ⊠ Z3Irrep) ≈ ones(6, 6)
     φ = (1 + sqrt(5)) / 2
-    @test Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1] / sqrt(2 + φ)
-    @test Smatrix(IsingAnyon) ≈ [1 sqrt(2) 1; sqrt(2) 0 -sqrt(2); 1 -sqrt(2) 1] / 2
+    @test Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1]
+    @test Smatrix(IsingAnyon) ≈ [1 sqrt(2) 1; sqrt(2) 0 -sqrt(2); 1 -sqrt(2) 1]
 
     # S matrix is symmetric
     @test transpose(Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)
     @test transpose(Smatrix(FibonacciAnyon ⊠ IsingAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ IsingAnyon)
     @test transpose(Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})) ≈ Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})
     @test transpose(Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon)) ≈ Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon)
+
+    # S matrix is tensor producted when sectors are Deligne tensor producted
+    @test Smatrix(FibonacciAnyon ⊠ FibonacciAnyon) ≈ kron(Smatrix(FibonacciAnyon), Smatrix(FibonacciAnyon))
+    @test Smatrix(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(FibonacciAnyon), Smatrix(IsingAnyon))
+    @test Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Smatrix(IsingAnyon), Smatrix(TimeReversed{IsingAnyon}))
+    @test Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon) ≈ kron(Smatrix(TimeReversed{FibonacciAnyon}), Smatrix(IsingAnyon))
 end
 
 @testset "Total quantum dimension" begin
-    @test dim(Z2Irrep) ≈ sqrt(2)
-    @test dim(Z3Irrep) ≈ sqrt(3)
-    @test dim(FermionParity) ≈ sqrt(2)
-    @test dim(Z2Irrep ⊠ Z3Irrep) ≈ sqrt(6)
+    @test sqDim(Z2Irrep) ≈ 2
+    @test sqDim(Z3Irrep) ≈ 3
+    @test sqDim(FermionParity) ≈ 2
+    @test sqDim(Z2Irrep ⊠ Z3Irrep) ≈ 6
     φ = (1 + sqrt(5)) / 2
-    @test dim(FibonacciAnyon) ≈ sqrt(2 + φ)
-    @test dim(IsingAnyon) ≈ 2
-    @test dim(FibonacciAnyon ⊠ FibonacciAnyon) ≈ 2 + φ
-    @test dim(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 4
+    @test sqDim(FibonacciAnyon) ≈ 2 + φ
+    @test sqDim(IsingAnyon) ≈ 4
+    @test sqDim(FibonacciAnyon ⊠ FibonacciAnyon) ≈ (2 + φ)^2
+    @test sqDim(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 16
 end
 
-@testset "Multiplicative central charge" begin
-    @test ξ(IsingAnyon) ≈ cispi(1 / 8)
-    @test ξ(TimeReversed{IsingAnyon}) ≈ cispi(-1 / 8)
-    @test ξ(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 1
-    @test ξ(FibonacciAnyon) ≈ cispi(- 7 / 5 / 2)
-    @test ξ(TimeReversed{FibonacciAnyon}) ≈ cispi(7 / 5 / 2)
-    @test ξ(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ 1
-    @test ξ(FibonacciAnyon ⊠ FibonacciAnyon) ≈ ξ(FibonacciAnyon)^2
-    @test ξ(FibonacciAnyon ⊠ IsingAnyon) ≈ ξ(FibonacciAnyon) * ξ(IsingAnyon)
+@testset "Topological central charge" begin
+    @test topological_central_charge(IsingAnyon) ≈ cispi(1 / 8)
+    @test topological_central_charge(TimeReversed{IsingAnyon}) ≈ cispi(-1 / 8)
+    @test topological_central_charge(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ 1
+    @test topological_central_charge(FibonacciAnyon) ≈ cispi(- 7 / 5 / 2)
+    @test topological_central_charge(TimeReversed{FibonacciAnyon}) ≈ cispi(7 / 5 / 2)
+    @test topological_central_charge(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ 1
+    @test topological_central_charge(FibonacciAnyon ⊠ FibonacciAnyon) ≈ topological_central_charge(FibonacciAnyon)^2
+    @test topological_central_charge(FibonacciAnyon ⊠ IsingAnyon) ≈ topological_central_charge(FibonacciAnyon) * topological_central_charge(IsingAnyon)
 end
 
 include("multifusion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using TestExtras
 using TensorKitSectors
 using LinearAlgebra: Diagonal
+using LinearAlgebra: I as identity_matrix
 
 include("newsectors.jl")
 using .NewSectors
@@ -204,29 +205,8 @@ end
     @test topological_spin(TimeReversed{FibonacciAnyon}(:τ)) == 2 // 5
     @test topological_spin.(anyonbasis(FibonacciAnyon ⊠ FibonacciAnyon)) == [0 // 1, -2 // 5, -2 // 5, 1 // 5]
     @test topological_spin.(anyonbasis(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon})) == [0 // 1, 2 // 5, -2 // 5, 0 // 1]
-    @test topological_spin.(anyonbasis(IsingAnyon ⊠ TimeReversed{IsingAnyon})) == [0 // 1, -1 // 16, 1 // 2, 1 // 16, 0 // 1, - 7 // 16, 1 // 2, 7 // 16, 0 // 1]
-    @test topological_spin.(anyonbasis(IsingAnyon ⊠ IsingAnyon)) == [0 // 1, 1 // 16, 1 // 2, 1 // 16, 1 // 8, - 7 // 16, 1 // 2, -7 // 16, 0 // 1]
-end
-
-@testset "T matrix" begin
-    @test Tmatrix(Z2Irrep) ≈ Diagonal([1, 1])
-    @test Tmatrix(Z3Irrep) ≈ Diagonal([1, 1, 1])
-    @test Tmatrix(FermionParity) ≈ Diagonal([1, -1])
-    @test Tmatrix(Z2Irrep ⊠ Z3Irrep) ≈ Diagonal(ones(6))
-    @test Tmatrix(FibonacciAnyon) ≈ Diagonal([1, cispi(-4 / 5)])
-    @test Tmatrix(IsingAnyon) ≈ Diagonal([1, cispi(1 / 8), -1])
-    @test Tmatrix(TimeReversed{IsingAnyon}) ≈ Diagonal([1, cispi(-1 / 8), -1])
-    @test Tmatrix(TimeReversed{FibonacciAnyon}) ≈ Diagonal([1, cispi(4 / 5)])
-
-    @test Tmatrix(FibonacciAnyon ⊠ FibonacciAnyon) ≈ kron(Tmatrix(FibonacciAnyon), Tmatrix(FibonacciAnyon))
-    @test Tmatrix(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ kron(Tmatrix(FibonacciAnyon), Tmatrix(TimeReversed{FibonacciAnyon}))
-    @test Tmatrix(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Tmatrix(FibonacciAnyon), Tmatrix(IsingAnyon))
-    @test Tmatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Tmatrix(IsingAnyon), Tmatrix(TimeReversed{IsingAnyon}))
-
-    @test Tmatrix(A4Irrep) ≈ Diagonal([1, 1, 1, 1])
-
-    @test Diagonal(twist.(anyonbasis(IsingAnyon ⊠ FibonacciAnyon ⊠ TimeReversed{IsingAnyon}))) ≈ Tmatrix(IsingAnyon ⊠ FibonacciAnyon ⊠ TimeReversed{IsingAnyon})
-    @test Diagonal(twist.(anyonbasis(FibonacciAnyon ⊠ IsingAnyon))) ≈ Tmatrix(FibonacciAnyon ⊠ IsingAnyon)
+    @test topological_spin.(anyonbasis(IsingAnyon ⊠ TimeReversed{IsingAnyon})) == [0 // 1, -1 // 16, 1 // 16, 1 // 2, 0, 1 // 2, -7 // 16, 7 // 16, 0 // 1]
+    @test topological_spin.(anyonbasis(IsingAnyon ⊠ IsingAnyon)) == [0 // 1, 1 // 16, 1 // 16, 1 // 2, 1 // 8, 1 // 2, -7 // 16, -7 // 16, 0 // 1]
 end
 
 @testset "Hopf link" begin
@@ -239,27 +219,42 @@ end
     @test hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ)) ≈ -1
     @test hopflink(IsingAnyon(:ψ) ⊠ FibonacciAnyon(:τ), IsingAnyon(:σ) ⊠ FibonacciAnyon(:τ)) ≈ hopflink(IsingAnyon(:ψ), IsingAnyon(:σ)) * hopflink(FibonacciAnyon(:τ), FibonacciAnyon(:τ))
 end
-@testset "S matrix" begin
+@testset "S matrix, T matrix" begin
     @test Smatrix(Z2Irrep) ≈ ones(2, 2)
     @test Smatrix(Z3Irrep) ≈ ones(3, 3)
+    @test Smatrix(A4Irrep) ≈ [1, 1, 1, 3] * [1, 1, 1, 3]'
     @test Smatrix(FermionParity) ≈ ones(2, 2)
     @test Smatrix(Z2Irrep ⊠ Z3Irrep) ≈ ones(6, 6)
     φ = (1 + sqrt(5)) / 2
     @test Smatrix(FibonacciAnyon) ≈ [1 φ; φ -1]
     @test Smatrix(IsingAnyon) ≈ [1 sqrt(2) 1; sqrt(2) 0 -sqrt(2); 1 -sqrt(2) 1]
 
-    # S matrix is symmetric
-    @test transpose(Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)
-    @test transpose(Smatrix(FibonacciAnyon ⊠ IsingAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ IsingAnyon)
-    @test transpose(Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})) ≈ Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})
-    @test transpose(Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon)) ≈ Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon)
+    @test Tmatrix(Z2Irrep) ≈ Diagonal([1, 1])
+    @test Tmatrix(Z3Irrep) ≈ Diagonal([1, 1, 1])
+    @test Tmatrix(A4Irrep) ≈ Diagonal([1, 1, 1, 1])
+    @test Tmatrix(FermionParity) ≈ Diagonal([1, -1])
+    @test Tmatrix(Z2Irrep ⊠ Z3Irrep) ≈ Diagonal(ones(6))
+    @test Tmatrix(FibonacciAnyon) ≈ Diagonal([1, cispi(-4 / 5)])
+    @test Tmatrix(IsingAnyon) ≈ Diagonal([1, cispi(1 / 8), -1])
+    @test Tmatrix(TimeReversed{IsingAnyon}) ≈ Diagonal([1, cispi(-1 / 8), -1])
+    @test Tmatrix(TimeReversed{FibonacciAnyon}) ≈ Diagonal([1, cispi(4 / 5)])
 
-    # S matrix is tensor producted when sectors are Deligne tensor producted
-    @test Smatrix(FibonacciAnyon ⊠ FibonacciAnyon) ≈ kron(Smatrix(FibonacciAnyon), Smatrix(FibonacciAnyon))
-    @test Smatrix(FibonacciAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(FibonacciAnyon), Smatrix(IsingAnyon))
-    @test Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ kron(Smatrix(IsingAnyon), Smatrix(TimeReversed{IsingAnyon}))
-    @test Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon) ≈ kron(Smatrix(TimeReversed{FibonacciAnyon}), Smatrix(IsingAnyon))
-    @test Smatrix(IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon) ≈ kron(Smatrix(IsingAnyon), Smatrix(IsingAnyon), Smatrix(IsingAnyon))
+    umtc_list = [
+        FibonacciAnyon ⊠ FibonacciAnyon, FibonacciAnyon ⊠ IsingAnyon, IsingAnyon ⊠ TimeReversed{IsingAnyon},
+        TimeReversed{FibonacciAnyon} ⊠ IsingAnyon, IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon,
+        IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon ⊠ TimeReversed{IsingAnyon} ⊠ TimeReversed{FibonacciAnyon},
+    ]
+    for sector in umtc_list
+        @test anyonbasis(sector) == vec(collect(values(sector)))
+        vals = values(sector)
+        l = length(vals)
+        Smat = Smatrix(sector)
+        Tmat = Tmatrix(sector)
+        @test Smat ≈ reshape([hopflink(a, b) for a in vals, b in vals], (l, l))
+        @test Tmat ≈ Diagonal(vec(twist.(vals)))
+        @test transpose(Smat) ≈ Smat
+        @test Smat' * Smat ≈ identity_matrix(l) * sqdim(sector)
+    end
 end
 
 @testset "Ismodular" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,6 +205,8 @@ end
     @test Tvector(FibonacciAnyon ⊠ TimeReversed{FibonacciAnyon}) ≈ [1, cispi(4 / 5), cispi(-4 / 5), 1]
     @test Tvector(FibonacciAnyon ⊠ IsingAnyon) ≈ [1, cispi(1 / 8), cispi(-4 / 5), -1, cispi(1 / 8 - 4 / 5), - cispi(-4 / 5)]
     @test Tvector(IsingAnyon ⊠ TimeReversed{IsingAnyon}) ≈ [1, cispi(- 1 / 8), cispi(1 / 8), -1, 1, -1, -cispi(1 / 8), -cispi(-1 / 8), 1]
+
+    @test Tvector(A4Irrep) ≈ [1, 1, 1, 1]
 end
 
 @testset "Hopf link" begin
@@ -229,7 +231,7 @@ end
     @test transpose(Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ FibonacciAnyon)
     @test transpose(Smatrix(FibonacciAnyon ⊠ IsingAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ IsingAnyon)
     @test transpose(Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})) ≈ Smatrix(IsingAnyon ⊠ TimeReversed{IsingAnyon})
-    @test transpose(Smatrix(FibonacciAnyon ⊠ IsingAnyon)) ≈ Smatrix(FibonacciAnyon ⊠ IsingAnyon)
+    @test transpose(Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon)) ≈ Smatrix(TimeReversed{FibonacciAnyon} ⊠ IsingAnyon)
 end
 
 @testset "Total quantum dimension" begin

--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -69,19 +69,6 @@ end
     end
 end
 
-@testsuite "Anyonbasis and anyonindex" I -> begin
-    if !(Base.IteratorSize(values(I)) isa Base.IsInfinite)
-        for a in values(I)
-            ind = anyonindex(a)
-            @test a == anyonbasis(I, ind)
-        end
-        for i in 1:length(values(I))
-            a = anyonbasis(I, i)
-            @test i == anyonindex(a)
-        end
-    end
-end
-
 @testsuite "Fusion and dimensions" I -> begin
     for a in smallset(I), b in smallset(I)
         can_fuse(a, b) || continue

--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -69,6 +69,19 @@ end
     end
 end
 
+@testsuite "Anyonbasis and anyonindex" I -> begin
+    if !(Base.IteratorSize(values(I)) isa Base.IsInfinite)
+        for a in values(I)
+            ind = anyonindex(a)
+            @test a == anyonbasis(I, ind)
+        end
+        for i in 1:length(values(I))
+            a = anyonbasis(I, i)
+            @test i == anyonindex(a)
+        end
+    end
+end
+
 @testsuite "Fusion and dimensions" I -> begin
     for a in smallset(I), b in smallset(I)
         can_fuse(a, b) || continue


### PR DESCRIPTION
Add total quantum dimension, S matrix, multiplicative central charge functions. These data are gauge-independent and can be used to check a category efficiently.