### PR TITLE
Fix the bug of modular condition of S matrix

### DIFF
--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -8,7 +8,7 @@ export Irrep, GroupElement
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
 export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, fusiontensor, dual
-export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, topological_central_charge
+export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, issymmetric, istransparent, Muger_centralizier, topological_central_charge
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic
@@ -39,6 +39,7 @@ export ⊠, ⊗, ×
 export Cyclic, ℤ, ℤ₂, ℤ₃, ℤ₄, U₁, SU, SU₂, Dihedral, D₃, D₄, CU₁
 export Alternating, A₄
 export fℤ₂, fU₁, fSU₂
+export Müger_centralizier
 
 # public
 # ------

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -39,7 +39,6 @@ export ⊠, ⊗, ×
 export Cyclic, ℤ, ℤ₂, ℤ₃, ℤ₄, U₁, SU, SU₂, Dihedral, D₃, D₄, CU₁
 export Alternating, A₄
 export fℤ₂, fU₁, fSU₂
-export Müger_centralizier
 
 # public
 # ------

--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -8,7 +8,7 @@ export Irrep, GroupElement
 export Nsymbol, Fsymbol, Rsymbol, Asymbol, Bsymbol
 export sectorscalartype, fusionscalartype, braidingscalartype, dimscalartype
 export dim, sqrtdim, invsqrtdim, frobenius_schur_indicator, frobenius_schur_phase, twist, fusiontensor, dual
-export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, issymmetric, istransparent, Muger_centralizier, topological_central_charge
+export topological_spin, hopflink, Tmatrix, Smatrix, ismodular, topological_central_charge
 export otimes, deligneproduct, times
 export FusionStyle, UniqueFusion, MultipleFusion, SimpleFusion, GenericFusion, MultiplicityFreeFusion
 export BraidingStyle, NoBraiding, HasBraiding, SymmetricBraiding, Bosonic, Fermionic, Anyonic

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -721,7 +721,7 @@ We choose convention by restrict the returning value as rational numbers in (-4,
 function topological_central_charge(::Type{I}) where {I <: Sector}
     gauss_sum = sum(dim(a)^2 * twist(a) for a in values(I))
     Θ = abs(gauss_sum)
-    abs(gauss_sum) < sqrt(eps(float(Θ))) && return missing # For non-modular categories, central charge is also meaningful. See https://arxiv.org/pdf/1602.05946. For super modular category, Gauss sum vanishes, and its central charge needs to be defined in another manner: https://arxiv.org/pdf/1603.09294.
+    Θ < sqrt(eps(float(Θ))) && return missing # For non-modular categories, central charge is also meaningful. See https://arxiv.org/pdf/1602.05946. For super modular category, Gauss sum vanishes, and its central charge needs to be defined in another manner: https://arxiv.org/pdf/1603.09294.
     c_float = angle(gauss_sum) * 8 / (2π)
 
     isapprox(c_float, -4) && return 4 // 1

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -713,6 +713,31 @@ function ismodular(::Type{II}; kwargs...) where {II <: Sector}
 end
 
 """
+    issymmetric(::Type{I}; kwargs...) where {I <: Sector}
+
+Check whether a sector type `I` is symmetric, i.e. the S-matrix is fully degenerate.
+"""
+function issymmetric(::Type{I}; kwargs...) where {I <: Sector}
+    s = Smatrix(I)
+    dims = vec(dim.(values(I)))
+    return isapprox(s, dims * dims'; kwargs...)
+end
+
+"""
+    istransparent(a::I; kwargs...) where {I <: Sector}
+
+Check whether a sector `a` in sector type `I` braids trivially with other sectors in `I`.    
+"""
+istransparent(a::I; kwargs...) where {I <: Sector} = all(b -> isapprox(hopflink(a, b), dim(a) * dim(b); kwargs...), values(I))
+
+"""
+    Muger_centralizier(::Type{I}; kwargs...) where {I <: Sector}
+"""
+Muger_centralizier(::Type{I}; kwargs...) where {I <: Sector} = vec(collect(filter(obj -> istransparent(obj; kwargs...), values(I))))
+
+const Müger_centralizier = Muger_centralizier
+
+"""
     topological_central_charge(::Type{I}) where {I <: Sector}
 
 Return the topological central charge c of the braided sector type `I`, where c is determined mod 8.

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -691,7 +691,7 @@ hopflink(a::I, b::I) where {I <: Sector} = sum(dim(c) * tr(Rsymbol(a, b, c) * Rs
 """
      Smatrix(::Type{I}) where {I <: Sector}
 
-Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`.
+Return the S-matrix of the sector type `I`, which is a matrix containing the hopflinks of all pairs of sectors of type `I`, with the second sector being taken dual.
 The S-matrix is not normalized by the total quantum dimension here.
 """
 function Smatrix(::Type{I}) where {I <: Sector}
@@ -699,7 +699,7 @@ function Smatrix(::Type{I}) where {I <: Sector}
         throw(ArgumentError("Only defined for sectors with a finite number of simple objects"))
     vals = values(I)
     l = length(vals)
-    return reshape([hopflink(a, b) for a in vals, b in vals], (l, l))
+    return reshape([hopflink(a, dual(b)) for a in vals, b in vals], (l, l))
 end
 
 """

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -721,7 +721,7 @@ We choose convention by restrict the returning value as rational numbers in (-4,
 function topological_central_charge(::Type{I}) where {I <: Sector}
     gauss_sum = sum(dim(a)^2 * twist(a) for a in values(I))
     Θ = abs(gauss_sum)
-    Θ < sqrt(eps(float(Θ))) && return missing # For non-modular categories, central charge is also meaningful. See https://arxiv.org/pdf/1602.05946. For super modular category, Gauss sum vanishes, and its central charge needs to be defined in another manner: https://arxiv.org/pdf/1603.09294.
+    @assert Θ > sqrt(eps(float(Θ))) "Topological central charge is not defined for sector type $I" # For non-modular categories, central charge is also meaningful. See https://arxiv.org/pdf/1602.05946. For super modular category, Gauss sum vanishes, and its central charge needs to be defined in another manner: https://arxiv.org/pdf/1603.09294.
     c_float = angle(gauss_sum) * 8 / (2π)
 
     isapprox(c_float, -4) && return 4 // 1

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -713,13 +713,6 @@ function ismodular(::Type{II}; kwargs...) where {II <: Sector}
 end
 
 """
-    istransparent(a::I; kwargs...) where {I <: Sector}
-
-Check whether a sector `a` in sector type `I` braids trivially with other sectors in `I`.    
-"""
-istransparent(a::I; kwargs...) where {I <: Sector} = all(b -> isapprox(hopflink(a, b), dim(a) * dim(b); kwargs...), values(I))
-
-"""
     topological_central_charge(::Type{I}) where {I <: Sector}
 
 Return the topological central charge c of the braided sector type `I`, where c is determined mod 8.

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -713,29 +713,11 @@ function ismodular(::Type{II}; kwargs...) where {II <: Sector}
 end
 
 """
-    issymmetric(::Type{I}; kwargs...) where {I <: Sector}
-
-Check whether a sector type `I` is symmetric, i.e. the S-matrix is fully degenerate.
-"""
-function issymmetric(::Type{I}; kwargs...) where {I <: Sector}
-    s = Smatrix(I)
-    dims = vec(dim.(values(I)))
-    return isapprox(s, dims * dims'; kwargs...)
-end
-
-"""
     istransparent(a::I; kwargs...) where {I <: Sector}
 
 Check whether a sector `a` in sector type `I` braids trivially with other sectors in `I`.    
 """
 istransparent(a::I; kwargs...) where {I <: Sector} = all(b -> isapprox(hopflink(a, b), dim(a) * dim(b); kwargs...), values(I))
-
-"""
-    Muger_centralizier(::Type{I}; kwargs...) where {I <: Sector}
-"""
-Muger_centralizier(::Type{I}; kwargs...) where {I <: Sector} = vec(collect(filter(obj -> istransparent(obj; kwargs...), values(I))))
-
-const Müger_centralizier = Muger_centralizier
 
 """
     topological_central_charge(::Type{I}) where {I <: Sector}
@@ -744,9 +726,10 @@ Return the topological central charge c of the braided sector type `I`, where c 
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
 function topological_central_charge(::Type{I}) where {I <: Sector}
-    ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / dim(I)
-    isapprox(abs(ξ), 0) && return missing # For non-modular categories, central charge is also meaningful. See https://arxiv.org/pdf/1602.05946. For super modular category, Gauss sum vanishes, and its central charge needs to be defined in another manner: https://arxiv.org/pdf/1603.09294.
-    c_float = angle(ξ) * 8 / (2π)
+    gauss_sum = sum(dim(a)^2 * twist(a) for a in values(I))
+    Θ = abs(gauss_sum)
+    abs(gauss_sum) < sqrt(eps(float(Θ))) && return missing # For non-modular categories, central charge is also meaningful. See https://arxiv.org/pdf/1602.05946. For super modular category, Gauss sum vanishes, and its central charge needs to be defined in another manner: https://arxiv.org/pdf/1603.09294.
+    c_float = angle(gauss_sum) * 8 / (2π)
 
     isapprox(c_float, -4) && return 4 // 1
 

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -715,12 +715,12 @@ end
 """
     topological_central_charge(::Type{I}) where {I <: Sector}
 
-Return the topological central charge c of the modular sector type `I`, where c is determined mod 8.
+Return the topological central charge c of the braided sector type `I`, where c is determined mod 8.
 We choose convention by restrict the returning value as rational numbers in (-4, 4].
 """
 function topological_central_charge(::Type{I}) where {I <: Sector}
     ξ = sum(dim(a)^2 * twist(a) for a in values(I)) / dim(I)
-    @assert isapprox(abs(ξ), 1) "Sector $I is not modular"
+    isapprox(abs(ξ), 0) && return missing # For non-modular categories, central charge is also meaningful. See https://arxiv.org/pdf/1602.05946. For super modular category, Gauss sum vanishes, and its central charge needs to be defined in another manner: https://arxiv.org/pdf/1603.09294.
     c_float = angle(ξ) * 8 / (2π)
 
     isapprox(c_float, -4) && return 4 // 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,11 +51,11 @@ const sectorlist = (
 include("testsuite.jl")
 using .SectorTestSuite
 
-# @testset "Sector test suite" verbose = true begin
-#     for sectortype in sectorlist
-#         @time SectorTestSuite.test_sector(sectortype)
-#     end
-# end
+@testset "Sector test suite" verbose = true begin
+    for sectortype in sectorlist
+        @time SectorTestSuite.test_sector(sectortype)
+    end
+end
 
 @testset "Intertwiner relation for A4Irrep" begin
     ω = cis(2π / 3)
@@ -304,6 +304,10 @@ end
 @testset "Topological central charge" begin
     @test topological_central_charge(FermionParity) === missing
     @test topological_central_charge(FermionParity ⊠ Z2Irrep) === missing
+    @test topological_central_charge(Z2Irrep) == 0 // 1
+    @test topological_central_charge(A4Irrep) == 0 // 1
+    @test topological_central_charge(Z2Irrep ⊠ IsingAnyon) == 1 // 2
+    @test topological_central_charge(FibonacciAnyon ⊠ D4Irrep) == - 14 // 5
     @test topological_central_charge(IsingAnyon) == 1 // 2
     @test topological_central_charge(TimeReversed{IsingAnyon}) == - 1 // 2
     @test topological_central_charge(IsingAnyon ⊠ TimeReversed{IsingAnyon}) == 0 // 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -276,16 +276,11 @@ end
     ]
     UMTC_over_RepG_list = [Z2Irrep ⊠ IsingAnyon, Z3Irrep ⊠ FibonacciAnyon, D3Irrep ⊠ TimeReversed{IsingAnyon}, A4Irrep ⊠ FibonacciAnyon ⊠ TimeReversed{IsingAnyon}]
 
-    for sect in [Tannakian_list..., Super_Tannakian_list...]
+    for sect in [Tannakian_list..., Super_Tannakian_list..., UMTC_over_RepG_list...]
         @test !ismodular(sect)
     end
-
     for sect in UMTC_list
         @test ismodular(sect)
-    end
-
-    for sect in UMTC_over_RepG_list
-        @test !ismodular(sect)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,7 +266,7 @@ end
 end
 
 @testset "Ismodular" begin
-    Tannakian_list = [Z2Irrep, Z3Irrep, FermionParity, A4Irrep, D3Irrep, D4Irrep, Z2Irrep ⊠ D4Irrep, D3Irrep ⊠ A4Irrep]
+    Tannakian_list = [Z2Irrep, Z3Irrep, A4Irrep, D3Irrep, D4Irrep, Z2Irrep ⊠ D4Irrep, D3Irrep ⊠ A4Irrep]
     Super_Tannakian_list = [FermionParity, FermionParity ⊠ A4Irrep, FermionParity ⊠ Z3Irrep, D4Irrep ⊠ FermionParity]
     UMTC_list = [
         IsingAnyon, FibonacciAnyon, TimeReversed{IsingAnyon}, TimeReversed{FibonacciAnyon},
@@ -275,8 +275,8 @@ end
         IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon ⊠ TimeReversed{IsingAnyon} ⊠ TimeReversed{FibonacciAnyon},
     ]
     UMTC_over_RepG_list = [Z2Irrep ⊠ IsingAnyon, Z3Irrep ⊠ FibonacciAnyon, D3Irrep ⊠ TimeReversed{IsingAnyon}, A4Irrep ⊠ FibonacciAnyon ⊠ TimeReversed{IsingAnyon}]
-
-    for sect in [Tannakian_list..., Super_Tannakian_list..., UMTC_over_RepG_list...]
+    UMTC_over_sRepG_list = [Z2Irrep ⊠ FermionParity ⊠ IsingAnyon, FermionParity ⊠ Z3Irrep ⊠ FibonacciAnyon, D3Irrep ⊠ TimeReversed{IsingAnyon} ⊠ FermionParity, A4Irrep ⊠ FibonacciAnyon ⊠ FermionParity ⊠ TimeReversed{IsingAnyon}]
+    for sect in [Tannakian_list..., Super_Tannakian_list..., UMTC_over_RepG_list..., UMTC_over_sRepG_list...]
         @test !ismodular(sect)
     end
     for sect in UMTC_list

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,8 +297,6 @@ end
 end
 
 @testset "Topological central charge" begin
-    @test topological_central_charge(FermionParity) === missing
-    @test topological_central_charge(FermionParity ⊠ Z2Irrep) === missing
     @test topological_central_charge(Z2Irrep) == 0 // 1
     @test topological_central_charge(A4Irrep) == 0 // 1
     @test topological_central_charge(Z2Irrep ⊠ IsingAnyon) == 1 // 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,11 +51,11 @@ const sectorlist = (
 include("testsuite.jl")
 using .SectorTestSuite
 
-@testset "Sector test suite" verbose = true begin
-    for sectortype in sectorlist
-        @time SectorTestSuite.test_sector(sectortype)
-    end
-end
+# @testset "Sector test suite" verbose = true begin
+#     for sectortype in sectorlist
+#         @time SectorTestSuite.test_sector(sectortype)
+#     end
+# end
 
 @testset "Intertwiner relation for A4Irrep" begin
     ω = cis(2π / 3)
@@ -265,7 +265,7 @@ end
     end
 end
 
-@testset "Ismodular, issymmetric, istransparent and Müger_centralizier" begin
+@testset "Ismodular" begin
     Tannakian_list = [Z2Irrep, Z3Irrep, FermionParity, A4Irrep, D3Irrep, D4Irrep, Z2Irrep ⊠ D4Irrep, D3Irrep ⊠ A4Irrep]
     Super_Tannakian_list = [FermionParity, FermionParity ⊠ A4Irrep, FermionParity ⊠ Z3Irrep, D4Irrep ⊠ FermionParity]
     UMTC_list = [
@@ -278,30 +278,15 @@ end
 
     for sect in [Tannakian_list..., Super_Tannakian_list...]
         @test !ismodular(sect)
-        @test issymmetric(sect)
-        for charge in values(sect)
-            @test istransparent(charge)
-        end
-        @test Müger_centralizier(sect) == vec(collect(values(sect)))
     end
 
     for sect in UMTC_list
         @test ismodular(sect)
-        @test !issymmetric(sect)
-        for anyon in values(sect)
-            anyon == unit(sect) && continue
-            @test !istransparent(anyon)
-        end
-        @test Müger_centralizier(sect) == [unit(sect)]
     end
 
     for sect in UMTC_over_RepG_list
-        charge_part = (TensorKitSectors._sectors)(sect)[1]
         @test !ismodular(sect)
-        @test !issymmetric(sect)
-        @test map(x -> x[1], Müger_centralizier(sect)) == collect(values(charge_part))
     end
-
 end
 
 @testset "Total quantum dimension" begin
@@ -317,6 +302,8 @@ end
 end
 
 @testset "Topological central charge" begin
+    @test topological_central_charge(FermionParity) === missing
+    @test topological_central_charge(FermionParity ⊠ Z2Irrep) === missing
     @test topological_central_charge(IsingAnyon) == 1 // 2
     @test topological_central_charge(TimeReversed{IsingAnyon}) == - 1 // 2
     @test topological_central_charge(IsingAnyon ⊠ TimeReversed{IsingAnyon}) == 0 // 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,16 +265,43 @@ end
     end
 end
 
-@testset "Ismodular" begin
-    @test !ismodular(Z2Irrep)
-    @test !ismodular(Z3Irrep)
-    @test !ismodular(FermionParity)
-    @test !ismodular(A4Irrep)
-    @test !ismodular(IsingAnyon ⊠ Z2Irrep)
-    @test ismodular(IsingAnyon)
-    @test ismodular(FibonacciAnyon)
-    @test ismodular(TimeReversed{IsingAnyon})
-    @test ismodular(IsingAnyon ⊠ TimeReversed{IsingAnyon})
+@testset "Ismodular, issymmetric, istransparent and Müger_centralizier" begin
+    Tannakian_list = [Z2Irrep, Z3Irrep, FermionParity, A4Irrep, D3Irrep, D4Irrep, Z2Irrep ⊠ D4Irrep, D3Irrep ⊠ A4Irrep]
+    Super_Tannakian_list = [FermionParity, FermionParity ⊠ A4Irrep, FermionParity ⊠ Z3Irrep, D4Irrep ⊠ FermionParity]
+    UMTC_list = [
+        IsingAnyon, FibonacciAnyon, TimeReversed{IsingAnyon}, TimeReversed{FibonacciAnyon},
+        FibonacciAnyon ⊠ FibonacciAnyon, FibonacciAnyon ⊠ IsingAnyon, IsingAnyon ⊠ TimeReversed{IsingAnyon},
+        TimeReversed{FibonacciAnyon} ⊠ IsingAnyon, IsingAnyon ⊠ IsingAnyon ⊠ IsingAnyon,
+        IsingAnyon ⊠ FibonacciAnyon ⊠ IsingAnyon ⊠ TimeReversed{IsingAnyon} ⊠ TimeReversed{FibonacciAnyon},
+    ]
+    UMTC_over_RepG_list = [Z2Irrep ⊠ IsingAnyon, Z3Irrep ⊠ FibonacciAnyon, D3Irrep ⊠ TimeReversed{IsingAnyon}, A4Irrep ⊠ FibonacciAnyon ⊠ TimeReversed{IsingAnyon}]
+
+    for sect in [Tannakian_list..., Super_Tannakian_list...]
+        @test !ismodular(sect)
+        @test issymmetric(sect)
+        for charge in values(sect)
+            @test istransparent(charge)
+        end
+        @test Müger_centralizier(sect) == vec(collect(values(sect)))
+    end
+
+    for sect in UMTC_list
+        @test ismodular(sect)
+        @test !issymmetric(sect)
+        for anyon in values(sect)
+            anyon == unit(sect) && continue
+            @test !istransparent(anyon)
+        end
+        @test Müger_centralizier(sect) == [unit(sect)]
+    end
+
+    for sect in UMTC_over_RepG_list
+        charge_part = (TensorKitSectors._sectors)(sect)[1]
+        @test !ismodular(sect)
+        @test !issymmetric(sect)
+        @test map(x -> x[1], Müger_centralizier(sect)) == collect(values(charge_part))
+    end
+
 end
 
 @testset "Total quantum dimension" begin


### PR DESCRIPTION
Sorry for the mixing. Here the bug of the S matrix convention is: the current used one differs from the one in the modular equation $(ST)^3 = e^{2\pi i c / 8}S^2$ by a dual, and can be witnessed by running:
```julia
using TensorKitSectors, CategoryData

Cat = Object{PMFC{3, 1, 2, 1, 0, 2}}
@assert ismodular(Cat)
@show c = topological_central_charge(Cat) # 2 // 1
@show sqD = dim(Cat)^2 # approximately 3 up to a small machine error
Smat = Smatrix(Cat)
smat = Smat / dim(Cat)
Tmat = Tmatrix(Cat)
@show norm(transpose(smat) - smat) # 0.0
@show norm((smat * Tmat)^3 - smat^2 * cispi(c / 4)) # approximately 2 up to small machine error
smat_dual = smat[[1, 2, 3], [1, 3, 2]] # taking dual on the second (or the first, equivalent) slot
@show norm(transpose(smat_dual) - smat_dual) # 0.0
@show norm((smat_dual * Tmat)^3 - smat_dual^2 * cispi(c / 4)) # machine error
```
Since all objects in all test modular sector types in `TensorKitSectors` are self-dual, this bug cannot be tested within `TensorKitSectors` without introducing a new sector type or new dependence of packages.

A slight modification of the `topological_central_charge` function is added to allow all braided categories.