### PR TITLE
fix: Artin braid check over/underbraiding conventions

### DIFF
--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -278,29 +278,29 @@ end
     BraidingStyle(I) isa HasBraiding || return nothing
     for a in smallset(I), b in smallset(I), d in smallset(I)
         for f in ⊗(d, a)
-            Radf = Rsymbol(a, d, f)
+            Rdaf, Radf = Rsymbol(d, a, f), Rsymbol(a, d, f)
             for c in ⊗(a, b)
                 for e in intersect(⊗(c, d), ⊗(f, b))
-                    Rcde = Rsymbol(c, d, e)
+                    Rcde, Rdce = Rsymbol(c, d, e), Rsymbol(d, c, e)
                     Fdabefc = Fsymbol(d, a, b, e, f, c)
                     if FusionStyle(I) isa MultiplicityFreeFusion
                         RFR1 = Rcde * conj(Fdabefc) * conj(Radf)
-                        RFR2 = conj(Rcde) * conj(Fdabefc) * Radf
+                        RFR2 = conj(Rdce) * conj(Fdabefc) * Rdaf
                     else
-                        @tensor RFR1[ν, μ, λ, σ] := Rcde[ν, ρ] * conj(Fdabefc[κ, λ, μ, ρ]) * conj(Radf[σ, κ])
-                        @tensor RFR2[ν, μ, λ, σ] := conj(Rcde[ν, ρ]) * conj(Fdabefc[κ, λ, μ, ρ]) * Radf[σ, κ]
+                        @tensor RFR1[μ, ν, λ, σ] := Rcde[ν, ρ] * conj(Fdabefc[κ, λ, μ, ρ]) * conj(Radf[σ, κ])
+                        @tensor RFR2[μ, ν, λ, σ] := conj(Rdce[ρ, ν]) * conj(Fdabefc[κ, λ, μ, ρ]) * Rdaf[κ, σ]
                     end
                     FRF1, FRF2 = zero(RFR1), zero(RFR2)
                     for g in ⊗(d, b)
                         Fabdecg = Fsymbol(a, b, d, e, c, g)
                         Fadbefg = Fsymbol(a, d, b, e, f, g)
-                        Rbdg = Rsymbol(b, d, g)
+                        Rbdg, Rdbg = Rsymbol(b, d, g), Rsymbol(d, b, g)
                         if FusionStyle(I) isa MultiplicityFreeFusion
                             FRF1 += Fabdecg * Rbdg * conj(Fadbefg)
-                            FRF2 += conj(Fabdecg) * conj(Rbdg) * Fadbefg
+                            FRF2 += Fabdecg * conj(Rdbg) * conj(Fadbefg)
                         else
-                            @tensor FRF1[ν, μ, β, α] += Fabdecg[μ, ν, κ, λ] * Rbdg[κ, θ] * conj(Fadbefg[α, β, θ, λ])
-                            @tensor FRF2[ν, μ, β, α] += conj(Fabdecg[μ, ν, κ, λ]) * conj(Rbdg[κ, θ]) * Fadbefg[α, β, θ, λ]
+                            @tensor FRF1[μ, ν, β, α] += Fabdecg[μ, ν, κ, λ] * Rbdg[κ, θ] * conj(Fadbefg[α, β, θ, λ])
+                            @tensor FRF2[μ, ν, β, α] += Fabdecg[μ, ν, κ, λ] * conj(Rdbg[θ, κ]) * conj(Fadbefg[α, β, θ, λ])
                         end
                     end
                     @test isapprox(RFR1, FRF1; atol = 1.0e-12, rtol = 1.0e-12)

--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -278,29 +278,29 @@ end
     BraidingStyle(I) isa HasBraiding || return nothing
     for a in smallset(I), b in smallset(I), d in smallset(I)
         for f in ⊗(d, a)
-            Rdaf, Radf = Rsymbol(d, a, f), Rsymbol(a, d, f)
+            Radf = Rsymbol(a, d, f)
             for c in ⊗(a, b)
                 for e in intersect(⊗(c, d), ⊗(f, b))
-                    Rcde, Rdce = Rsymbol(c, d, e), Rsymbol(d, c, e)
+                    Rcde = Rsymbol(c, d, e)
                     Fdabefc = Fsymbol(d, a, b, e, f, c)
                     if FusionStyle(I) isa MultiplicityFreeFusion
-                        RFR1 = Rcde * conj(Fdabefc) * conj(Rdaf)
-                        RFR2 = conj(Rdce) * conj(Fdabefc) * Radf
+                        RFR1 = Rcde * conj(Fdabefc) * conj(Radf)
+                        RFR2 = conj(Rcde) * conj(Fdabefc) * Radf
                     else
-                        @tensor RFR1[ν, μ, λ, σ] := Rcde[ν, ρ] * conj(Fdabefc[κ, λ, μ, ρ]) * conj(Rdaf[σ, κ])
-                        @tensor RFR2[ν, μ, λ, σ] := conj(Rdce[ν, ρ]) * conj(Fdabefc[κ, λ, μ, ρ]) * Radf[σ, κ]
+                        @tensor RFR1[ν, μ, λ, σ] := Rcde[ν, ρ] * conj(Fdabefc[κ, λ, μ, ρ]) * conj(Radf[σ, κ])
+                        @tensor RFR2[ν, μ, λ, σ] := conj(Rcde[ν, ρ]) * conj(Fdabefc[κ, λ, μ, ρ]) * Radf[σ, κ]
                     end
                     FRF1, FRF2 = zero(RFR1), zero(RFR2)
                     for g in ⊗(d, b)
                         Fabdecg = Fsymbol(a, b, d, e, c, g)
                         Fadbefg = Fsymbol(a, d, b, e, f, g)
-                        Rbdg, Rdbg = Rsymbol(b, d, g), Rsymbol(d, b, g)
+                        Rbdg = Rsymbol(b, d, g)
                         if FusionStyle(I) isa MultiplicityFreeFusion
                             FRF1 += Fabdecg * Rbdg * conj(Fadbefg)
-                            FRF2 += conj(Fabdecg) * conj(Rdbg) * Fadbefg
+                            FRF2 += conj(Fabdecg) * conj(Rbdg) * Fadbefg
                         else
                             @tensor FRF1[ν, μ, β, α] += Fabdecg[μ, ν, κ, λ] * Rbdg[κ, θ] * conj(Fadbefg[α, β, θ, λ])
-                            @tensor FRF2[ν, μ, β, α] += conj(Fabdecg[μ, ν, κ, λ]) * conj(Rdbg[κ, θ]) * Fadbefg[α, β, θ, λ]
+                            @tensor FRF2[ν, μ, β, α] += conj(Fabdecg[μ, ν, κ, λ]) * conj(Rbdg[κ, θ]) * Fadbefg[α, β, θ, λ]
                         end
                     end
                     @test isapprox(RFR1, FRF1; atol = 1.0e-12, rtol = 1.0e-12)


### PR DESCRIPTION
This seems to fix the artin braid test failures when I tried testing these within QuantumKitHub/SUNRepresentations.jl#44 and QuantumKitHub/CategoryData.jl#35. 

The thing that confused me was the drawing in https://quantumkithub.github.io/TensorKit.jl/stable/man/fusiontrees/#Manipulations-on-a-fusion-tree. It's correct, but the bar notation there for the R-symbol actually means underbraiding, and not just conjugating, so I got some index orders incorrect. Concretely for one case, $\overline{R}^{da}_f$ actually corresponds to `conj(Radf)`. This didn't confuse me in the hexagon case because you don't mix over- and underbraiding per equation.

That this didn't get caught within TensorKitSectors is a bit confusing: the switching of first two indices doesn't matter for multiplicity-free fusion; the R-symbol is always a phase then, but we have `A4Irrep` to make a matrix, and mixed with e.g. `FibonacciAnyon` I'd have expected the importance of the ordering to show up, but I guess not. Although to be fair, sectors which were failing in CategoryData weren't necessarily of `GenericFusion` type.

I hope with this getting merged and released that we can also properly get the integration tests running for SUNRepresentations and CategoryData.