### PR TITLE
Speed up `getindex` and `findindex` for `ProductSector` `SectorValues`

### DIFF
--- a/src/TensorKitSectors.jl
+++ b/src/TensorKitSectors.jl
@@ -58,7 +58,7 @@ end
 
 # imports
 # -------
-using Base: SizeUnknown, HasLength, IsInfinite
+using Base: SizeUnknown, HasLength, HasShape, IsInfinite
 using Base: HasEltype, EltypeUnknown
 using Base.Iterators: product, filter
 using Base: @assume_effects

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -19,16 +19,31 @@ function _kron_promote(A₁, B₁, sz₁, sz₂)
 end
 
 # Manhattan based distance enumeration: I is supposed to be one-based index
-# TODO: is there any way to make this faster?
 
 # forward mapping from multidimensional to single Manhattan index
 @inline function num_manhattan_points(d::Int, sz::Dims{1})
     return Int(sz[1] > d)
 end
+
+# when sz[k] > d for every k, then x_k < sz[k] - 1 is never violated by any split of d units among N axes (one x_k is maximally d, and sz[k] - 1 ≥ d covers that)
+# so the bound drops -> calculate ways to write d as an ordered sum of N nonnegative integers,
+# which is the number of compositions of d into N parts
+@inline function _compositions(d::Int, ::Val{N}) where {N}
+    try
+        return binomial(d + N - 1, N - 1)
+    catch e
+        e isa OverflowError || rethrow()
+        return nothing # fallback to recursion
+    end
+end
 @inline function num_manhattan_points(d::Int, sz::Dims{N}) where {N}
     d == 0 && return 1
+    if N ≥ 3 && all(>(d), sz)
+        c = _compositions(d, Val(N))
+        isnothing(c) || return c
+    end
     num = 0
-    for i in 1:min(sz[1], d + 1)
+    for i in 1:min(sz[1], d + 1) # for N = 2 the loop is already linear
         num += num_manhattan_points(d - i + 1, Base.tail(sz))
     end
     return num
@@ -79,7 +94,7 @@ function manhattan_to_multidimensional_index(index::Int, sz::Dims{N}) where {N}
     index == 1 && return ntuple(one, Val(N))
     offset = 1
     d = 1
-    while true
+    while true # reason for the boundscheck
         currentlayer = num_manhattan_points(d, sz)
         if index <= offset + currentlayer
             break
@@ -92,3 +107,44 @@ function manhattan_to_multidimensional_index(index::Int, sz::Dims{N}) where {N}
     index -= offset
     return invertlocaloffset(d, index - 1, sz)
 end
+
+# tabulation of the mapping to avoid repeated calls to manhattan_to_multidimensional_index
+# and to_manhattan_index
+struct MTable{N}
+    multi::Vector{NTuple{N, Int}} # Manhattan index -> multi-index
+    lin::Array{Int, N} # multi-index -> Manhattan index
+end
+
+function build_table(sz::Dims{N}) where {N}
+    n = prod(sz)
+    multi = Vector{NTuple{N, Int}}(undef, n)
+    k = 0
+    for J in CartesianIndices(sz)
+        k += 1
+        multi[k] = Tuple(J)
+    end
+    sort!(multi; by = J -> (sum(J), J)) # sort first by distance, matches isless on ProductSector
+    lin = Array{Int, N}(undef, sz)
+    for i in 1:n
+        lin[CartesianIndex(multi[i])] = i
+    end
+    return MTable{N}(multi, lin)
+end
+
+const TABLES = IdDict{DataType, Any}()
+const TABLE_LOCK = ReentrantLock() # dictionaries aren't thread-safe for concurrent mutation
+# within TensorKit no problem: OhMyThreads allows concurrent calls into e.g. sectors(V)
+
+@inline function mtable(::Type{I}, sz::Dims{N}) where {I, N}
+    t = get(TABLES, I, nothing)
+    if t === nothing
+        t = @lock TABLE_LOCK get!(() -> build_table(sz), TABLES, I)
+    end
+    return t::MTable{N} # re-establish concrete typing for downstream
+end
+
+# refuse to tabulate absurdly large label sets
+# GradedSpace NTuple storage is only used for finite sectors
+# not sure what a reasonable limit is, might be edited to smaller value
+# depending on findings of NTuple vs Dict performance tests
+const MAXTABLE = 2^20

--- a/src/product.jl
+++ b/src/product.jl
@@ -39,12 +39,29 @@ end
 function _size(::SectorValues{I}) where {I <: ProductSector}
     return map(s -> _length(values(s)), _sectors(I))
 end
-function Base.getindex(P::SectorValues{I}, i::Int) where {I <: ProductSector}
-    inds = manhattan_to_multidimensional_index(i, _size(P))
+# finite <=> the product iterator has a shape, which is exactly the condition
+# under which Vect[I] uses NTuple storage (pre potential cutoff)
+@inline function tabulate(P::SectorValues, sz::Dims)
+    return Base.IteratorSize(P) isa Union{HasLength, HasShape} && prod(sz) ≤ MAXTABLE
+end
+Base.@propagate_inbounds function Base.getindex(P::SectorValues{I}, i::Int) where {I <: ProductSector}
+    sz = _size(P)
+    @boundscheck checksectorindex(P, i)
+    inds = if tabulate(P, sz)
+        @inbounds mtable(I, sz).multi[i]
+    else
+        manhattan_to_multidimensional_index(i, sz)
+    end
     return I(getindex.(values.(_sectors(I)), inds))
 end
 function findindex(P::SectorValues{I}, c::I) where {I <: ProductSector}
-    return to_manhattan_index(findindex.(values.(_sectors(I)), Tuple(c)), _size(P))
+    J = findindex.(values.(_sectors(I)), Tuple(c))
+    sz = _size(P)
+    return if tabulate(P, sz)
+        @inbounds mtable(I, sz).lin[CartesianIndex(J)]
+    else
+        to_manhattan_index(J, sz)
+    end
 end
 
 function Base.iterate(P::SectorValues{I}, i = 1) where {I <: ProductSector}

--- a/src/sectors.jl
+++ b/src/sectors.jl
@@ -74,16 +74,17 @@ Base.IteratorEltype(::Type{<:SectorValues}) = HasEltype()
 Base.eltype(::Type{SectorValues{I}}) where {I <: Sector} = I
 Base.values(::Type{I}) where {I <: Sector} = SectorValues{I}()
 
-Base.@propagate_inbounds function Base.getindex(
-        v::SectorValues{I}, i::Int
-    ) where {I <: Sector}
-    @boundscheck begin
-        if Base.IteratorSize(v) === HasLength()
-            1 ≤ i ≤ length(v) || throw(BoundsError(v, i))
-        else
-            1 ≤ i || throw(BoundsError(v, i))
-        end
+@inline function checksectorindex(v::SectorValues, i::Integer)
+    if Base.IteratorSize(v) isa Union{HasLength, HasShape}
+        1 ≤ i ≤ length(v) || throw(BoundsError(v, i))
+    else
+        1 ≤ i || throw(BoundsError(v, i))
     end
+    return nothing
+end
+
+Base.@propagate_inbounds function Base.getindex(v::SectorValues{I}, i::Int) where {I <: Sector}
+    @boundscheck checksectorindex(v, i)
     for (j, c) in enumerate(v)
         j == i && return c
     end


### PR DESCRIPTION
TLDR: it's faster.

The current Manhattan-distance enumeration was implemented just recursively, which scaled like distance^(N-1) for N sector types in the product sector. When it comes to finite product sectors within TensorKit, `getindex` and `findindex` are used frequently in constructing graded spaces.

Here, I propose a speedup that exists of two parts.
1) For a fixed Manhattan distance, there are cases where one can just combinatorically calculate the number of grid points at this distance. There's thus a shortcut now in `num_manhattan_points` in these cases. Otherwise, still calculate recursively. I also limited this behavior to a certain amount of product sector types just based on complexity, but it might be an unnecessary complexity (other definition) of the code.
2) Calculate the entire multi-index to Manhattan index and vice-versa just once, as it's a bijection, in such a way that still respects `isless` of product sectors, and cache this in a table. Then `findindex` and `getindex` are just array lookups instead of recursive calculations. 

There's also a fix related to checking bounds. This is because, as of now, when getting an index outside of the length of sector values, it would get stuck in a while loop. I added `checksectorindex` to check the bounds. Everything's done in a way that functions can be inlined, but I don't really know how that works. I think it's worth it in this case, but please be critical about it. This infinite loop is now unreachable through the API.

A comment before the benchmarks: As of now I set the cutoff to tabulating to some value large enough that finite product sector types will most likely tabulate. Whether this tabulation matters in practice depends on `Vect[I]` using `NTuple` or `SectorDict` storage. Currently, every finite sectors falls within the former, but I'm looking into introducing a cutoff even in the finite case, which I hope to share soon. This is based on performance within TensorKit's functions which frequently access this storage.

Benchmarks: I checked decoding/`getindex` and encoding/`findindex`, as well as 4 functions within TensorKit which access the sector values in some way: `dim`, `fuse`, `sectors` and `blocksectors` on product spaces (not cached!). I ran this for 2 finite product sector types under the tabulation limit, an infinite product sector type, and a finite one above the limit (just the decoding/encoding).

<details>

<summary>Benchmark results </summary>

### Current main

| Case | decode | encode | dim(V) | sectors(V) | fuse(V,V) | blocksectors |
|---|---|---|---|---|---|---|
| A: Z4^⊠3(n=64) | 15.52 µs | 11.89 µs | 5.73 µs | 436 ns | 2.08 ms | 316 µs |
| B: Z8^⊠3 (n=512) | 529 µs | 398 µs | 274 µs | 2.71 µs | 602 ms | 169 ms |
| C: U1⊠SU2⊠FermionParity | 61.6 µs | 73.5 ns | 672 ns | 325 ns | 372 µs | 48.1 µs |
| D: Z8^⊠6 (n=262144) | 1.76 ms | 1.61 ms | / | / | / | / |

### Changes

| Case | decode | encode | dim(V) | sectors(V) | fuse(V,V) | blocksectors |
|---|---|---|---|---|---|---|
| A: Z4^⊠3 (n=64) | 696 ns | 1.07 µs | 3.91 µs | 324 ns | 1.71 ms | 269 µs |
| B: Z8^⊠3 (n=512) | 5.5 µs | 9.04 µs | 192 µs | 1.66 µs | 404 ms | 155 ms |
| C: U1⊠SU2⊠FermionParity | 50.0 µs | 100.0 ns | 588 ns | 324 ns | 225 µs | 35.9 µs |
| D: Z8^⊠6 (n=262144) | 15.5 ns | 21.2 ns | / | / | / | / |

### Speedups

| Case | decode | encode | dim(V) | sectors(V) | fuse(V,V) | blocksectors |
|---|---|---|---|---|---|---|
| A: Z4^⊠3 (n=64) | **22.3×** | **11.2×** | **1.46×** | 1.34× | **1.22×** | **1.18×** |
| B: Z8^⊠3 (n=512) | **96.2×** | **44.1×** | **1.42×** | 1.64× | **1.49×** | **1.09×** |
| C: U1⊠SU2⊠FermionParity | 1.23× | 0.74× | 1.14× | 1.00× | 1.65× | 1.34× |
| D: Z8^⊠6 (n=262144) | **~113,000×** | **~76,000×** | / | / | / | / |

### Standard errors (old / new)

| Case | decode | encode | dim(V) | sectors(V) | fuse(V,V) | blocksectors |
|---|---|---|---|---|---|---|
| A: Z4^⊠3 (n=64) | 0.6% / 0.8% | 0.5% / 0.9% | 0.8% / 1.0% | 24.6% / 40.6% | 0.3% / 2.9% | 0.9% / 0.4% |
| B: Z8^⊠3 (n=512) | 0.6% / 0.9% | 0.9% / 1.1% | 0.9% / 0.6% | 42.9% / 0.9% | 1.2% / 1.4% | 0.7% / 2.5% |
| C: U1⊠SU2⊠FermionParity | 0.7% / 1.0% | 0.8% / 0.8% | 1.5% / 0.8% | 1.5% / 2.3% | 0.5% / 0.6% | 0.5% / 0.9% |
| D: Z8^⊠6 (n=262144) | 0.8% / 1.8% | 0.5% / 1.2% | / | / | / | / |

### Case D: Z8^⊠6 (n=262144), after execution

| metric | old | new | ratio |
|---|---|---|---|
| decode, deepest index | 1.76 ms | 15.5 ns | ~113,000× |
| encode, deepest index | 1.61 ms | 21.2 ns | ~76,000× |

</details>

Important observations:
- Speedup is more noticeable the larger the finite product sector type.
- For case D actually, I first had a different approach to building the table built on the recursive decoder per index. However, this was ridiculously expensive (reasoned in hindsight, of course), and added an extra factor "number of sector types in the product". `build_table` now enumerates the grid directly instead of this recursive decoder, which is O(n logn) due to sorting. 
- The regression in case C actually doesn't matter within TensorKit, since this Manhattan code only matters when `Vect[I]` has `NTuple` storage. So this regression is only within TensorKitSectors. The last 4 columns here should really be ignored, as they don't pass the Manhattan code anyway.

I want to stress again this tabulation cutoff being arbitrary, and it really just mattering within TensorKitSectors. My preliminary benchmarks on `NTuple` vs `SectorDict` storage hint at the former being efficient from the order of ~16-32 sectors, which is way below 2^20. So really, if I end up drawing as conclusion that the cutoff should be around 16-32, then this PR is practically useful for people studying product sector types ≤ 16 sectors 🤣 Thanks for listening to my TED talk.