### PR TITLE
fix: have `LargeZNIrrep` actually have unknown size of sector values

### DIFF
--- a/src/irreps/znirrep.jl
+++ b/src/irreps/znirrep.jl
@@ -84,7 +84,7 @@ dual(c::AnyZNIrrep{N}) where {N} = typeof(c)(N - c.n)
 
 Base.IteratorSize(::Type{SectorValues{<:ZNIrrep}}) = HasLength()
 # for larger values it doesn't make sense to store the sectors as a tuple
-Base.IteratorSize(::Type{SectorValues{<:LargeZNIrrep}}) = SizeUnknown()
+Base.IteratorSize(::Type{SectorValues{I}}) where {I <: LargeZNIrrep} = SizeUnknown()
 
 Base.length(::SectorValues{I}) where {I <: AnyZNIrrep} = modulus(I)
 Base.iterate(::SectorValues{I}, i = 0) where {I <: AnyZNIrrep} = i == modulus(I) ? nothing : (I(i), i + 1)


### PR DESCRIPTION
`LargeZNIrrep` wasn't actually avoiding the NTuple storage method in graded spaces. Tracked it down to some annoying Julia dispatch.

Before:
```julia
julia> I = ZNIrrep{200};

julia> II = LargeZNIrrep{200};

julia> Vect[I]
ZNSpace{200} (alias for GradedSpace{ZNIrrep{200}, NTuple{200, Int64}})

julia> Vect[II]
GradedSpace{LargeZNIrrep{200}, NTuple{200, Int64}}
```

After:
```julia
julia> Vect[II]
GradedSpace{LargeZNIrrep{200}, TensorKit.SortedVectorDict{LargeZNIrrep{200}, Int64}}
```

