### PR TITLE
test `GenericUnit` property is reserved for multifusion

### DIFF
--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -8,6 +8,8 @@ using TensorKitSectors: TensorKitSectors as TKS
     @test @testinferred(hash(sc)) == hash(deepcopy(sc))
     if UnitStyle(I) isa SimpleUnit
         @test @testinferred(unit(sc)) == @testinferred(unit(I))
+    else
+        @test length(@testinferred(allunits(I))) > 1
     end
     @testinferred dual(sc)
     @testinferred dim(sc)


### PR DESCRIPTION
Even though fusion categories are technically multifusion, `UnitStyle` is reserved really to have to account for colorings. Things are simplified if the single-color property of fusion categories is enforced.